### PR TITLE
Create reusable algolia InstantSearch wrapper

### DIFF
--- a/src/components/SearchInput/SearchInput.stories.js
+++ b/src/components/SearchInput/SearchInput.stories.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import SearchInput from '../SearchInput';
 
+import MiseInstantSearch from '../../lib/algolia/MiseInstantSearch/MiseInstantSearch';
+
 export default {
   title: 'Components|SearchInput',
   component: SearchInput,
 };
 
 export const Default = () => (
-  <SearchInput />
+  <MiseInstantSearch>
+    <SearchInput />
+  </MiseInstantSearch>
 );

--- a/src/components/SearchInput/index.js
+++ b/src/components/SearchInput/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { connectSearchBox } from 'react-instantsearch-dom';
+
 import { color, font, fontSize } from '../../styles';
 import { SearchIcon, Close } from '../DesignTokens/Icon';
 
-import algoliasearch from 'algoliasearch/lite';
-import { InstantSearch, connectSearchBox, Hits } from 'react-instantsearch-dom';
 
 const StyledSearch = styled.form`
   height: 5rem;
@@ -31,7 +31,7 @@ const StyledSearch = styled.form`
       -webkit-appearance:none;
     }
   }
-  
+
   button {
     background: none;
     border: none;
@@ -47,7 +47,7 @@ const StyledSearch = styled.form`
     fill: ${color.regentGray};
     position: absolute;
     z-index: 1;
-    
+
     &.search-icon {
       height: 2rem;
       left: 0;
@@ -83,37 +83,17 @@ const StyledSearchBox = ({ currentRefinement, refine, placeholder }) => (
 
 const SearchBox = connectSearchBox(StyledSearchBox);
 
-const SearchInput = ({
-  applicationId,
-  searchAPIKey,
-  children,
-  placeholder,
-  indexName,
-}) => (
-    <InstantSearch
-      indexName={indexName}
-      searchClient={algoliasearch(applicationId,searchAPIKey)}
-    >
-        <SearchBox
-          placeholder={placeholder}
-        />
-      {children}
-    </InstantSearch>
+const SearchInput = ({ placeholder }) => (
+  <SearchBox
+    placeholder={placeholder}
+  />
 );
 
 SearchInput.propTypes = {
-  children: PropTypes.node,
-  indexName: PropTypes.string,
-  applicationId: PropTypes.string,
-  searchAPIKey: PropTypes.string,
   placeholder: PropTypes.string,
 }
 
 SearchInput.defaultProps = {
-  applicationId: 'latency',
-  searchAPIKey: '6be0576ff61c053d5f9a3225e2a90f76',
-  indexName: 'bestbuy',
-  children: <Hits />,
   placeholder: 'What are you curious about?'
 }
 

--- a/src/lib/algolia/MiseInstantSearch/MiseInstantSearch.js
+++ b/src/lib/algolia/MiseInstantSearch/MiseInstantSearch.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import algoliasearch from 'algoliasearch/lite';
+import { InstantSearch, Hits } from 'react-instantsearch-dom';
+
+const searchClient = algoliasearch(
+  'Y1FNZXUI30',
+  '3ef655917b64bb548c4bf36e9dab9913',
+);
+
+const MiseInstantSearch = ({ children }) => (
+  <InstantSearch
+    indexName="everest_search_development"
+    searchClient={searchClient}
+  >
+    {children}
+    <Hits />
+  </InstantSearch>
+);
+
+MiseInstantSearch.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+};
+
+export default MiseInstantSearch;


### PR DESCRIPTION
wrap any component we use from algolia instant search with `MiseInstantSearch` and it will use our index and hits from that index