### PR TITLE
undo the connect changes, small tweaks

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,6 @@
         "useBuiltIns": "entry"
       }
     ]
-  ]
+  ],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@atk/mise-ui",
   "version": "0.1.1",
   "dependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@testing-library/jest-dom": "^5.1.1",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^8.1.0",

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -26,12 +26,18 @@ const ImageWrapper = styled.div`
   position: relative;
   margin-bottom: ${spacing.xsm};
   height: 16.2rem;
+  width: 100%;
 
   .no-image & {
     display: flex;
     align-items: center;
     margin-bottom: ${spacing.xxsm};
     height: auto;
+  }
+
+  img {
+    display: block;
+    width: 100%;
   }
 
   ${breakpoint('tablet')`
@@ -97,7 +103,6 @@ const StyledBadge = styled(Badge)`
 `;
 
 export function StandardCard({
-  badgeType,
   className,
   commentCount,
   contentType,
@@ -110,7 +115,10 @@ export function StandardCard({
   imageAlt,
   imageUrl,
   isFavorited,
+  objectId,
   onClick,
+  siteKey,
+  siteKeyFavorites,
   title,
 }) {
   return (
@@ -124,7 +132,7 @@ export function StandardCard({
         ) : null }
         <StyledBadge
           className={className}
-          type={badgeType}
+          type={siteKey}
         />
         { stickers ?
           <StickerGroup>
@@ -147,7 +155,10 @@ export function StandardCard({
             className={className}
             role="button"
             isFavorited={isFavorited}
+            objectId={objectId}
             onClick={onClick}
+            siteKey={siteKeyFavorites}
+            title={title}
           />
         ) : null }
       </TitleWrapper>
@@ -163,7 +174,6 @@ export function StandardCard({
 }
 
 StandardCard.propTypes = {
-  badgeType: PropTypes.oneOf(['atk', 'cco', 'cio', 'kids']).isRequired,
   displayFavoritesButton: PropTypes.bool,
   contentType: PropTypes.string.isRequired,
   commentCount: PropTypes.number,
@@ -174,7 +184,10 @@ StandardCard.propTypes = {
   imageUrl: PropTypes.string,
   imageAlt: PropTypes.string,
   isFavorited: PropTypes.bool,
+  objectId: PropTypes.string,
   onClick: PropTypes.func,
+  siteKey: PropTypes.oneOf(['atk', 'cco', 'cio', 'kids', 'school', 'shop']).isRequired,
+  siteKeyFavorites: PropTypes.oneOf(['atk', 'cco', 'cio']).isRequired,
   title: PropTypes.string.isRequired,
 };
 
@@ -186,6 +199,7 @@ StandardCard.defaultProps = {
   displayFavoritesButton: false,
   displayLockIcon: false,
   isFavorited: false,
+  objectId: null,
   onClick: null,
 };
 

--- a/src/components/Cards/shared/FavoriteButton/index.js
+++ b/src/components/Cards/shared/FavoriteButton/index.js
@@ -26,7 +26,7 @@ const StyledFavoriteButton = styled.button`
     stroke: ${color.white};
   }
 
-  ${props => props.isFavorited && css`
+  &.is-favorited {
     [class*="ribbon"] {
       fill: ${color.eclipse};
     }
@@ -45,29 +45,38 @@ const StyledFavoriteButton = styled.button`
         stroke: ${color.eclipse};
       }
     }
-  `}
+  }
 `;
 
-const FavoriteButton = ({ isFavorited, onClick }) => (
+const FavoriteButton = ({
+  objectId,
+  onClick,
+  siteKey,
+  title,
+}) => (
   <StyledFavoriteButton
-    isFavorited={isFavorited}
+    className="favorite-action"
+    data-document-title={title}
+    data-favoritable-id={objectId}
+    data-origin-site={siteKey}
     onClick={onClick}
   >
     <FavoriteRibbon
       ariaHidden="true"
-      ariaLabel={isFavorited ? 'Remove from favorites' : 'Save to favorites'}
+      ariaLabel={'Save to favorites'}
       className="favorite-ribbon"
     />
   </StyledFavoriteButton>
 );
 
 FavoriteButton.propTypes = {
-  isFavorited: PropTypes.bool,
+  objectId: PropTypes.string.isRequired,
   onClick: PropTypes.func,
+  siteKey: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 FavoriteButton.defaultProps = {
-  isFavorited: true,
   onClick: null,
 };
 

--- a/src/components/SearchCurrentRefinements/index.js
+++ b/src/components/SearchCurrentRefinements/index.js
@@ -7,7 +7,7 @@ import { color, font, fontSize } from '../../styles';
 
 const RefinementsList = styled.ul`
   display: flex;
-  padding: 0;
+  padding: 1.2rem 0 1rem 0;
   margin: 0;
 `;
 
@@ -37,7 +37,7 @@ const CurrentRefinements = ({ items, refine }) => (
     {
       items.map(category => (
         category.items.map(({ label, value }) => (
-          <RefinementListItem key={`clear-refinement--${value}`}>
+          <RefinementListItem key={`clear-refinement--${label}`}>
             <Refinement>
               <RefinementLabel>
                 {label}

--- a/src/components/SearchInput/SearchInput.stories.js
+++ b/src/components/SearchInput/SearchInput.stories.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { connectSearchBox } from 'react-instantsearch-dom';
+
+import LabelFrame from '../LabelFrame';
 import SearchInput from '../SearchInput';
 
 import MiseInstantSearch from '../../lib/algolia/MiseInstantSearch/MiseInstantSearch';
-
-const ConnectedSearchInput = connectSearchBox(SearchInput);
-
 
 export default {
   title: 'Components|SearchInput',
@@ -14,6 +12,8 @@ export default {
 
 export const Default = () => (
   <MiseInstantSearch>
-    <ConnectedSearchInput />
+    <LabelFrame label="Component">
+      <SearchInput />
+    </LabelFrame>
   </MiseInstantSearch>
 );

--- a/src/components/SearchInput/index.js
+++ b/src/components/SearchInput/index.js
@@ -1,6 +1,7 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { connectSearchBox } from 'react-instantsearch-dom';
 
 import { color, font, fontSize } from '../../styles';
 import { SearchIcon, Close } from '../DesignTokens/Icon';
@@ -80,12 +81,20 @@ const StyledSearchBox = ({ currentRefinement, refine, placeholder }) => (
   </StyledSearch>
 )
 
-StyledSearchBox.propTypes = {
+const SearchBox = connectSearchBox(StyledSearchBox);
+
+const SearchInput = ({ placeholder }) => (
+  <SearchBox
+    placeholder={placeholder}
+  />
+);
+
+SearchInput.propTypes = {
   placeholder: PropTypes.string,
 }
 
-StyledSearchBox.defaultProps = {
+SearchInput.defaultProps = {
   placeholder: 'What are you curious about?'
 }
 
-export default StyledSearchBox;
+export default SearchInput;

--- a/src/components/SearchInput/index.js
+++ b/src/components/SearchInput/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { connectSearchBox } from 'react-instantsearch-dom';
@@ -66,20 +66,77 @@ const StyledSearch = styled.form`
   }
 `;
 
-const StyledSearchBox = ({ currentRefinement, refine, placeholder }) => (
-  <StyledSearch noValidate action="" role="search">
-    <SearchIcon fill={color.regentGray} />
-    <input
-      type="search"
-      value={currentRefinement}
-      onChange={event => refine(event.currentTarget.value)}
-      placeholder={placeholder}
-    />
-    <button type="reset" onClick={() => refine('')} hidden={!currentRefinement}>
-      <Close ariaLabel="clear search input" fill={color.regentGray} />
-    </button>
-  </StyledSearch>
-)
+class StyledSearchBox extends Component {
+  constructor(props) {
+    super(props);
+    this.timerId = null;
+  }
+
+  onInputMount = (input) => {
+    this.input = input;
+  }
+
+  onChangeDebounced = (event) => {
+    const { refine, delay } = this.props;
+    const value = event.currentTarget.value;
+
+    clearTimeout(this.timerId);
+    this.timerId = setTimeout(() => refine(value), delay);
+  };
+
+  onReset = () => {
+    const { refine } = this.props;
+    refine('');
+    this.input.value = '';
+    this.input.focus();
+  }
+
+  onSubmit = (e) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+    this.input.blur();
+    const { refine } = this.props;
+    refine(this.input.value);
+    return false;
+  }
+
+  render() {
+    const { currentRefinement, refine, placeholder } = this.props;
+    return (
+      <StyledSearch
+        noValidate
+        action=""
+        onSubmit={this.onSubmit}
+        onReset={this.onReset}
+        role="search"
+      >
+        <SearchIcon
+          fill={color.regentGray}
+        />
+        <input
+          type="search"
+          defaultValue={currentRefinement}
+          ref={this.onInputMount}
+          onChange={this.onChangeDebounced}
+          placeholder={placeholder}
+        />
+        <button type="reset" onClick={() => refine('')} hidden={!currentRefinement}>
+          <Close ariaLabel="clear search input" fill={color.regentGray} />
+        </button>
+      </StyledSearch>
+    );
+  }
+};
+
+StyledSearchBox.propTypes = {
+  currentRefinement: PropTypes.string.isRequired,
+  delay: PropTypes.number,
+  refine: PropTypes.func.isRequired,
+};
+
+StyledSearchBox.defaultProps = {
+  delay: 250,
+};
 
 const SearchBox = connectSearchBox(StyledSearchBox);
 

--- a/src/components/SearchRefinementList/index.js
+++ b/src/components/SearchRefinementList/index.js
@@ -39,7 +39,6 @@ const RefinementList = ({ attribute, items, refine }) => (
               />
             ))
           }
-          key={`${attribute}-showmore`}
         />
       )
     }

--- a/src/components/SearchResultsCount/index.js
+++ b/src/components/SearchResultsCount/index.js
@@ -11,7 +11,7 @@ const StatsWrapper = styled.p`
 
 const Stats = ({ nbHits }) => (
   <StatsWrapper>
-    {`${nbHits} Results`}
+    {`${nbHits.toLocaleString()} Results`}
   </StatsWrapper>
 );
 

--- a/src/components/SearchSortBy/SearchSortBy.stories.js
+++ b/src/components/SearchSortBy/SearchSortBy.stories.js
@@ -2,11 +2,8 @@ import React from 'react';
 
 import LabelFrame from '../LabelFrame';
 import SearchSortBy from '../SearchSortBy';
-import { connectSortBy } from 'react-instantsearch-dom';
 
 import MiseInstantSearch from '../../lib/algolia/MiseInstantSearch/MiseInstantSearch';
-
-const ConnectedSearchSortBy = connectSortBy(SearchSortBy);
 
 export default {
   title: 'Components|SearchSortBy',
@@ -15,13 +12,8 @@ export default {
 
 export const Default = () => (
   <MiseInstantSearch>
-    <ConnectedSearchSortBy
-      defaultRefinement="everest_search_development"
-      items={[
-        { 'value': 'everest_search_development', label: 'Relevance' },
-        { 'value': 'everest_search_popularity_desc_development', label: 'Popularity' },
-        { 'value': 'everest_search_published_date_desc_development', label: 'Publish Date' },
-      ]}
-    />
+    <LabelFrame label="Component">
+      <SearchSortBy />
+    </LabelFrame>
   </MiseInstantSearch>
 );

--- a/src/components/SearchSortBy/index.js
+++ b/src/components/SearchSortBy/index.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { connectSortBy } from 'react-instantsearch-dom';
 
+import { ShowHide } from '../ShowHide';
 import { color, font, fontSize } from '../../styles';
 
 const SearchSortByList = styled.ul`
@@ -66,14 +68,28 @@ const SortBy = ({ items, refine }) => (
   </SearchSortByList>
 );
 
-SortBy.propTypes = {
+const CustomSortBy = connectSortBy(SortBy);
+
+const SearchSortBy = ({ defaultRefinement, items }) => (
+  <ShowHide
+    isFieldset
+    label="Sort By"
+  >
+    <CustomSortBy
+      defaultRefinement={defaultRefinement}
+      items={items}
+    />
+  </ShowHide>
+);
+
+SearchSortBy.propTypes = {
   /** Name of algolia index that should be selected on initial page render. */
   defaultRefinement: PropTypes.string,
   /** List of 'hits' returned by algolia. */
   items: PropTypes.array,
 };
 
-SortBy.defaultProps = {
+SearchSortBy.defaultProps = {
   defaultRefinement: 'everest_search_development',
   items: [
     { 'value': 'everest_search_development', label: 'Relevance' },
@@ -82,4 +98,4 @@ SortBy.defaultProps = {
   ],
 };
 
-export default SortBy;
+export default SearchSortBy;

--- a/src/components/ShowMoreLess/index.js
+++ b/src/components/ShowMoreLess/index.js
@@ -19,7 +19,7 @@ const ShowMoreLessButton = styled.button`
   text-transform: uppercase;
 `;
 
-const ShowMoreLess = ({ initialCount, items, key }) => {
+const ShowMoreLess = ({ initialCount, items, id }) => {
   const [hidden, toggleHidden] = useState(true);
   let initialItems = null;
   let restItems = null;
@@ -37,12 +37,12 @@ const ShowMoreLess = ({ initialCount, items, key }) => {
             </ShowMoreLessInitial>
             <ShowMoreLessRest
               hidden={hidden || null}
-              id={`show-hide--${key}`}
+              id={`show-hide--${id}`}
             >
               {restItems.map(item => item)}
             </ShowMoreLessRest>
             <ShowMoreLessButton
-              aria-controls={`show-hide--${key}`}
+              aria-controls={`show-hide--${id}`}
               aria-expanded={!hidden}
               onClick={() => { toggleHidden(!hidden); }}
             >
@@ -60,12 +60,12 @@ const ShowMoreLess = ({ initialCount, items, key }) => {
 };
 
 ShowMoreLess.propTypes = {
+  /** Unique id for this ShowMoreLess. */
+  id: PropTypes.string.isRequired,
   /** Initial number of 'items' that render before clicking 'Show More'. */
   initialCount: PropTypes.number.isRequired,
   /** The list of 'items' to render. */
   items: PropTypes.array.isRequired,
-  /** Unique idea for this ShowMoreLess. */
-  key: PropTypes.string.isRequired,
 };
 
 export default ShowMoreLess;

--- a/yarn.lock
+++ b/yarn.lock
@@ -514,7 +514,7 @@
     "@babel/helper-remap-async-to-generator" "^7.8.3"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
 
-"@babel/plugin-proposal-class-properties@7.8.3", "@babel/plugin-proposal-class-properties@^7.1.0", "@babel/plugin-proposal-class-properties@^7.7.0":
+"@babel/plugin-proposal-class-properties@7.8.3", "@babel/plugin-proposal-class-properties@^7.1.0", "@babel/plugin-proposal-class-properties@^7.7.0", "@babel/plugin-proposal-class-properties@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz#5e06654af5cd04b608915aada9b2a6788004464e"
   integrity sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==


### PR DESCRIPTION
* we *can* connect in mise-ui!
* small changes based on what is rendered in jarvis

[UPDATE]
* prop updates to `StandardCard` and `FavoriteRibbon` based on `jarvis` needs
* use `is-favorited` classname to adjust styles for `FavoriteRibbon` since this classname is set by an external script at run-time (not render time) via the favorites widget code
* debounce the search input, make it an uncontrolled component. This allows `jarvis` to not pass `searchState` down the render tree and still allows users to freely type in the input
* include `@babel/plugin-proposal-class-properties` so that we can have arrow functions on classes
* use `id` as prop instead of `key` for `ShowMoreLess` b/c `key` is a reserved prop name w/React