### PR TITLE
Ja site list filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "react-instantsearch-dom": "^6.3.0",
     "react-scripts": "3.3.1",
     "styled-components-breakpoint": "^2.1.1",
-    "styled-normalize": "^8.0.7",
-    "watch": "^1.0.2"
+    "styled-normalize": "^8.0.7"
   },
   "peerDependencies": {
     "react": "^16.12.0",
@@ -24,7 +23,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "cross-env BABEL_ENV=production babel src -d dist",
+    "build": "cross-env BABEL_ENV=production babel src -d dist --ignore 'src/**/*.stories.js','src/**/*.spec.js','src/setupTests.js','src/serviceWorker.js'",
     "watch": "watch 'yarn run build' ./src",
     "test": "jest",
     "lint": "./node_modules/.bin/eslint .",
@@ -71,7 +70,8 @@
     "cross-env": "^7.0.2",
     "jest": "24.9.0",
     "react-test-renderer": "^16.12.0",
-    "styled-components": "^5.0.1"
+    "styled-components": "^5.0.1",
+    "watch": "^1.0.2"
   },
   "description": "Design system and component library for America's Test Kitchen",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-instantsearch-dom": "^6.3.0",
     "react-scripts": "3.3.1",
     "styled-components-breakpoint": "^2.1.1",
-    "styled-normalize": "^8.0.7"
+    "styled-normalize": "^8.0.7",
+    "watch": "^1.0.2"
   },
   "peerDependencies": {
     "react": "^16.12.0",
@@ -24,6 +25,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "cross-env BABEL_ENV=production babel src -d dist",
+    "watch": "watch 'yarn run build' ./src",
     "test": "jest",
     "lint": "./node_modules/.bin/eslint .",
     "eject": "react-scripts eject",

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -58,7 +58,7 @@ Badge.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string,
   fill: PropTypes.string,
-  type: PropTypes.oneOf(['atk', 'cio', 'cco', 'kids', 'school', 'shop',]).isRequired,
+  type: PropTypes.oneOf(['atk', 'cio', 'cco', 'kids', 'school', 'shop']).isRequired,
 }
 
 Badge.defaultProps = {

--- a/src/components/Cards/StandardCard/StandardCard.stories.js
+++ b/src/components/Cards/StandardCard/StandardCard.stories.js
@@ -27,7 +27,7 @@ export const LoggedIn = () => (
     objectId=""
     onClick={action('favorites-click')}
     title={text("Title", "Plastic Food Storage Containers")}
-    url="https://www.americastestkitchen.com/equipment_reviews/1879-plastic-food-storage-containers?ref=new_search_experience_2"
+    href="https://www.americastestkitchen.com/equipment_reviews/1879-plastic-food-storage-containers?ref=new_search_experience_2"
   />
 );
 
@@ -46,7 +46,7 @@ export const LoggedOut = () => (
     siteKeyFavorites="cio"
     stickers={[{type: 'priority', text: 'New'}, {type: 'editorial', text: 'Quick'}]}
     title={text("Title", "Congee (Chinese Rice Porridge) with Stir-Fried Ground Pork")}
-    url="https://www.cooksillustrated.com/recipes/12381-congee-chinese-rice-porridge-with-stir-fried-ground-pork?extcode=MASCD00L0&ref=new_search_experience_2"
+    href="https://www.cooksillustrated.com/recipes/12381-congee-chinese-rice-porridge-with-stir-fried-ground-pork?extcode=MASCD00L0&ref=new_search_experience_2"
   />
 );
 
@@ -62,6 +62,6 @@ export const NoImage = () => (
     siteKeyFavorites="cio"
     stickers={[{type: 'editorial', text: 'Make Ahead'}]}
     title={text("Title", "Congee (Chinese Rice Porridge) with Stir-Fried Ground Pork")}
-    url="https://www.cooksillustrated.com/recipes/12381-congee-chinese-rice-porridge-with-stir-fried-ground-pork?extcode=MASCD00L0&ref=new_search_experience_2"
+    href="https://www.cooksillustrated.com/recipes/12381-congee-chinese-rice-porridge-with-stir-fried-ground-pork?extcode=MASCD00L0&ref=new_search_experience_2"
   />
 );

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -24,7 +24,6 @@ const StyledStandardCard = styled.article`
 
 const ImageWrapper = styled.div`
   position: relative;
-  margin-bottom: ${spacing.xsm};
   width: 100%;
 
   .no-image & {
@@ -105,6 +104,7 @@ export function StandardCard({
   className,
   commentCount,
   contentType,
+  contentTypeFormatted,
   ctaText,
   ctaUrl,
   displayCommentCount,
@@ -167,7 +167,7 @@ export function StandardCard({
       </a>
       <Attributions
         commentCount={commentCount}
-        contentType={contentType}
+        contentType={contentTypeFormatted || contentType}
         displayLockIcon={displayLockIcon}
         displayCommentCount={displayCommentCount}
       />
@@ -179,6 +179,7 @@ export function StandardCard({
 StandardCard.propTypes = {
   displayFavoritesButton: PropTypes.bool,
   contentType: PropTypes.string.isRequired,
+  contentTypeFormatted: PropTypes.string,
   commentCount: PropTypes.number,
   ctaText: PropTypes.string,
   ctaUrl: PropTypes.string,
@@ -198,6 +199,7 @@ StandardCard.propTypes = {
 
 StandardCard.defaultProps = {
   commentCount: null,
+  contentTypeFormatted: null,
   ctaText: '',
   ctaUrl: '',
   displayCommentCount: false,

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -24,28 +24,19 @@ const StyledStandardCard = styled.article`
 
 const ImageWrapper = styled.div`
   position: relative;
-  height: 16.2rem;
+  margin-bottom: ${spacing.xsm};
   width: 100%;
 
   .no-image & {
     display: flex;
     align-items: center;
     margin-bottom: ${spacing.xxsm};
-    height: auto;
   }
 
   img {
     display: block;
     width: 100%;
   }
-
-  ${breakpoint('tablet')`
-    height: 27.2rem;
-
-    .no-image & {
-      height: auto;
-    }
-  `}
 `;
 
 const TitleWrapper = styled.div`
@@ -200,6 +191,7 @@ StandardCard.propTypes = {
   onClick: PropTypes.func,
   siteKey: PropTypes.oneOf(['atk', 'cco', 'cio', 'kids', 'school', 'shop']).isRequired,
   siteKeyFavorites: PropTypes.oneOf(['atk', 'cco', 'cio']).isRequired,
+  stickers: PropTypes.array,
   title: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
 };
@@ -215,6 +207,7 @@ StandardCard.defaultProps = {
   imageUrl: '',
   isFavorited: false,
   onClick: null,
+  stickers: [],
 };
 
 export default StandardCard;

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -119,11 +119,11 @@ export function StandardCard({
   siteKey,
   siteKeyFavorites,
   title,
-  url,
+  href,
 }) {
   return (
     <StyledStandardCard className={imageUrl ? '' : 'no-image'}>
-      <a href={url}>
+      <a href={href}>
         <ImageWrapper>
           { imageUrl ? (
             <Image
@@ -193,7 +193,7 @@ StandardCard.propTypes = {
   siteKeyFavorites: PropTypes.oneOf(['atk', 'cco', 'cio']).isRequired,
   stickers: PropTypes.array,
   title: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
+  href: PropTypes.string.isRequired,
 };
 
 StandardCard.defaultProps = {

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -157,7 +157,7 @@ export function StandardCard({
               className={className}
               role="button"
               isFavorited={isFavorited}
-              object={objectId}
+              objectId={objectId}
               onClick={onClick}
               siteKey={siteKeyFavorites}
               title={title}

--- a/src/components/Cards/shared/FavoriteButton/index.js
+++ b/src/components/Cards/shared/FavoriteButton/index.js
@@ -27,7 +27,7 @@ const StyledFavoriteButton = styled.button`
     stroke: ${color.white};
   }
 
-  &.is-favorited {
+  &.favorited {
     [class*="ribbon"] {
       fill: ${color.eclipse};
     }

--- a/src/components/SearchCurrentRefinements/index.js
+++ b/src/components/SearchCurrentRefinements/index.js
@@ -7,11 +7,13 @@ import { color, font, fontSize } from '../../styles';
 
 const RefinementsList = styled.ul`
   display: flex;
+  flex-wrap: wrap;
   padding: 1.2rem 0 1rem 0;
   margin: 0;
 `;
 
 const RefinementListItem = styled.li`
+  margin-bottom: 0.5rem;
   margin-right: 1.6rem;
 `;
 
@@ -32,15 +34,24 @@ const RefinementClearButton = styled.button`
   width: 0.8rem;
 `;
 
+const labelMap = {
+  atk: 'America\'s Test Kitchen',
+  cco: 'Cook\'s Country',
+  cio: 'Cook\'s Illustrated',
+  kids: 'ATK Kids',
+  school: 'Cooking School',
+  shop: 'ATK Shop',
+};
+
 const CurrentRefinements = ({ items, refine }) => (
   <RefinementsList>
     {
       items.map(category => (
-        category.items.map(({ label, value }) => (
+        category.items.map(({ attribute, label, value }) => (
           <RefinementListItem key={`clear-refinement--${label}`}>
             <Refinement>
               <RefinementLabel>
-                {label}
+                {labelMap[label] || label}
               </RefinementLabel>
               <RefinementClearButton onClick={(e) => { e.preventDefault(); refine(value); }}>
                 <Close fill={color.nobel} />

--- a/src/components/SearchRefinementList/components/SearchRefinementFilter.js
+++ b/src/components/SearchRefinementList/components/SearchRefinementFilter.js
@@ -66,7 +66,7 @@ const SearchRefinementFilter = ({
 }) => (
   <SearchRefinementFilterLabel
     altFill={altFill}
-    htmlFor={`${attribute}--${value}`}
+    htmlFor={`${attribute}--${label}`}
     onClick={(e) => { e.preventDefault(); refine(value); }}
   >
     {
@@ -106,7 +106,7 @@ SearchRefinementFilter.propTypes = {
   /** Algolia attribute used to filter results. */
   attribute: PropTypes.string.isRequired,
   /** Number of hits for this filter value. */
-  count: PropTypes.number.isRequired,
+  count: PropTypes.number,
   includeCount: PropTypes.bool,
   /** Is this filter selected? */
   isRefined: PropTypes.bool.isRequired,
@@ -115,11 +115,12 @@ SearchRefinementFilter.propTypes = {
   /** Call this with the value of a filter to refine results based on filter. */
   refine: PropTypes.func.isRequired,
   /** Value of filter to be used for refining results. */
-  value: PropTypes.array.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired,
 };
 
 SearchRefinementFilter.defaultProps = {
   altFill: null,
+  count: null,
   includeCount: false,
 }
 

--- a/src/components/SearchRefinementList/components/SearchRefinementFilter.js
+++ b/src/components/SearchRefinementList/components/SearchRefinementFilter.js
@@ -54,81 +54,60 @@ const SearchRefinementFilterCount = styled.span`
   color: ${color.nobel};
 `;
 
-const keyToButton = key => (
-  {
-    'atk': {
-      altFill: color.tomato,
-      label: 'America\'s Test Kitchen',
-    },
-    'cco': {
-      altFill: color.denim,
-      label: 'Cook\'s Country',
-    },
-    'cio': {
-      altFill: color.cork,
-      label: 'Cook\'s Illustrated',
-    },
-    'kids': {
-      altFill: color.jade,
-      label: 'ATK Kids',
-    },
-    'school': {
-      altFill: color.tomato,
-      label: 'Cooking School',
-    },
-    'shop': {
-      altFill: color.tomato,
-      label: 'ATK Shop',
-    },
-  }[key] || {}
+const SearchRefinementFilter = ({
+  altFill,
+  attribute,
+  count,
+  includeCount,
+  isRefined,
+  label,
+  refine,
+  value,
+}) => (
+  <SearchRefinementFilterLabel
+    altFill={altFill}
+    htmlFor={`${attribute}--${value}`}
+    onClick={(e) => { e.preventDefault(); refine(value); }}
+  >
+    {
+      isRefined ? (
+        <SearchRefinementFilterCheck>
+          <Checkmark />
+        </SearchRefinementFilterCheck>
+      ) : null
+    }
+    <SearchRefinementFilterCheckbox
+      id={`search-site-list--${value}`}
+      type="checkbox"
+    />
+    {
+      attribute === 'search_site_list' ? (
+        <Badge
+          className="search-refinement__badge"
+          fill={isRefined ? altFill : color.eclipse}
+          type={value}
+        />
+      ) : null
+    }
+    {
+      includeCount ? (
+        <span>
+          {label} <SearchRefinementFilterCount>{`(${count})`}</SearchRefinementFilterCount>
+        </span>
+      ) : (
+        label
+      )
+    }
+  </SearchRefinementFilterLabel>
 );
 
-const SearchRefinementFilter = ({ attribute, count, isRefined, label: key, refine, value }) => {
-  const { altFill, label } = keyToButton(key);
-  const wrapperProps = {
-    altFill,
-    htmlFor: `${attribute}--${key}`,
-  };
-  return (
-    <SearchRefinementFilterLabel {...wrapperProps} onClick={(e) => { e.preventDefault(); refine(value); }}>
-      {
-        isRefined ? (
-          <SearchRefinementFilterCheck>
-            <Checkmark />
-          </SearchRefinementFilterCheck>
-        ) : null
-      }
-      <SearchRefinementFilterCheckbox
-        id={`search-site-list--${key}`}
-        type="checkbox"
-      />
-      {
-        attribute === 'search_site_list' ? (
-          <Badge
-            className="search-refinement__badge"
-            fill={isRefined ? altFill : color.eclipse}
-            type={key}
-          />
-        ) : null
-      }
-      {
-        label ? (
-          label
-        ) : (
-          <span>
-            {key} <SearchRefinementFilterCount>{`(${count})`}</SearchRefinementFilterCount>
-          </span>
-        )
-      }
-    </SearchRefinementFilterLabel>
-  );
-};
-
 SearchRefinementFilter.propTypes = {
+  altFill: PropTypes.string,
   /** Algolia attribute used to filter results. */
   attribute: PropTypes.string.isRequired,
   /** Number of hits for this filter value. */
   count: PropTypes.number.isRequired,
+  includeCount: PropTypes.bool,
   /** Is this filter selected? */
   isRefined: PropTypes.bool.isRequired,
   /** Filter label */
@@ -138,5 +117,10 @@ SearchRefinementFilter.propTypes = {
   /** Value of filter to be used for refining results. */
   value: PropTypes.array.isRequired,
 };
+
+SearchRefinementFilter.defaultProps = {
+  altFill: null,
+  includeCount: false,
+}
 
 export default SearchRefinementFilter;

--- a/src/components/SearchRefinementList/index.js
+++ b/src/components/SearchRefinementList/index.js
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import ShowMoreLess from '../ShowMoreLess';
 import SearchRefinementFilter from './components/SearchRefinementFilter';
 import { ShowHide } from '../ShowHide';
+import { color, font, fontSize } from '../../styles';
 
 const SearchRefinementListRefinements = styled.div`
   border: none;
@@ -13,16 +14,56 @@ const SearchRefinementListRefinements = styled.div`
   padding: 0;
 `;
 
-const RefinementList = ({ attribute, items, refine }) => (
+const siteMap = [
+  {
+    altFill: color.tomato,
+    label: 'America\'s Test Kitchen',
+    value: 'atk',
+  },
+  {
+    altFill: color.denim,
+    label: 'Cook\'s Country',
+    value: 'cco',
+  },
+  {
+    altFill: color.cork,
+    label: 'Cook\'s Illustrated',
+    value: 'cio',
+  },
+  {
+    altFill: color.jade,
+    label: 'ATK Kids',
+    value: 'kids',
+  },
+  {
+    altFill: color.tomato,
+    label: 'Cooking School',
+    value: 'school',
+  },
+  {
+    altFill: color.tomato,
+    value: 'shop',
+    label: 'ATK Shop',
+  }
+];
+
+const RefinementList = ({ attribute, currentRefinement, items, refine }) => (
   <SearchRefinementListRefinements>
     {
       attribute === 'search_site_list' ? (
-        items.map(item => (
+        siteMap.map(site => (
           <SearchRefinementFilter
-            {...item}
+            {...site}
             attribute={attribute}
-            key={`${attribute}-${item.label}`}
-            refine={refine}
+            includeCount={false}
+            isRefined={currentRefinement.includes(site.value)}
+            key={`${attribute}-${site.value}`}
+            refine={(value) => {
+              const next = currentRefinement.includes(value)
+                ? currentRefinement.filter(current => current !== value)
+                : currentRefinement.concat(value);
+              refine(next);
+            }}
           />
         ))
       ) : (
@@ -48,10 +89,13 @@ const RefinementList = ({ attribute, items, refine }) => (
 const CustomRefinementList = connectRefinementList(RefinementList);
 
 const SearchRefinementList = (props) => {
-  const { showHideLabel, ...restProps } = props;
+  const { showHideLabel, operator, ...restProps } = props;
   return (
     <ShowHide isFieldset label={showHideLabel}>
-      <CustomRefinementList {...restProps} />
+      <CustomRefinementList
+        operator={operator}
+        {...restProps}
+      />
     </ShowHide>
   );
 };
@@ -59,6 +103,7 @@ const SearchRefinementList = (props) => {
 SearchRefinementList.propTypes = {
   /** Algolia attribute that is used to pull refinement values. */
   attribute: PropTypes.string.isRequired,
+  operator: PropTypes.oneOf(['and', 'or']),
   /** 'Title' of the list that will be put into clickable show/hide button */
   showHideLabel: PropTypes.string.isRequired,
   /** Initial number of refinement filters that are visible in the refinement list. */
@@ -66,6 +111,7 @@ SearchRefinementList.propTypes = {
 };
 
 SearchRefinementList.defaultProps = {
+  operator: 'and',
   transformItems: null,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6229,6 +6229,13 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+exec-sh@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
+  integrity sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==
+  dependencies:
+    merge "^1.2.0"
+
 exec-sh@^0.3.2:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
@@ -9459,6 +9466,11 @@ merge2@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
+
+merge@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
+  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 methods@~1.1.2:
   version "1.1.2"
@@ -14526,6 +14538,14 @@ warning@^4.0.2, warning@^4.0.3:
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
+
+watch@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/watch/-/watch-1.0.2.tgz#340a717bde765726fa0aa07d721e0147a551df0c"
+  integrity sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=
+  dependencies:
+    exec-sh "^0.2.0"
+    minimist "^1.2.0"
 
 watchpack@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
* `yarn run watch` will rebuild with any changes to `src` dir, only compiling the component files
* fix `objectId` and `favorited` classname for fav ribbon
* custom handling for the search site list to get the behavior and sorting we want (see below)
* clear facets when resetting search input (see below)
* default operator set as `and` for faceting

### Site Filter
The site list needs to be static so that it's always in the same order and so that it basically doesn't have to re-render aside from active/inactive states. Additionally, I added a lookup for translating 'atk' to 'Americas Test Kitchen' in the current filters list

### Reset Button
The current SERP experience clears the search input and resets any pre-selected facets when you click the 'reset' button. To get that behavior we need to wrap the reset button in a `connectCurrentRefinements` and have it live next to the connected search input. 