### PR TITLE
memo card in mise, connect filter wrapper to avoid display if no results

### DIFF
--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -191,7 +191,7 @@ StandardCard.propTypes = {
   objectId: PropTypes.string.isRequired,
   onClick: PropTypes.func,
   siteKey: PropTypes.oneOf(['atk', 'cco', 'cio', 'kids', 'school', 'shop']).isRequired,
-  siteKeyFavorites: PropTypes.oneOf(['atk', 'cco', 'cio']).isRequired,
+  siteKeyFavorites: PropTypes.oneOf(['atk', 'cco', 'cio']),
   stickers: PropTypes.array,
   title: PropTypes.string.isRequired,
   href: PropTypes.string.isRequired,
@@ -212,4 +212,7 @@ StandardCard.defaultProps = {
   stickers: [],
 };
 
-export default StandardCard;
+export default React.memo(StandardCard, (prevProps, nextProps) => (
+  prevProps.objectId === nextProps.objectId &&
+  prevProps.siteKey === nextProps.siteKey
+));

--- a/src/components/SearchInput/index.js
+++ b/src/components/SearchInput/index.js
@@ -117,7 +117,7 @@ StyledSearchBox.propTypes = {
 };
 
 StyledSearchBox.defaultProps = {
-  delay: 150,
+  delay: 200,
   onReset: null,
 };
 

--- a/src/components/SearchRefinementList/index.js
+++ b/src/components/SearchRefinementList/index.js
@@ -86,19 +86,17 @@ const RefinementList = ({ attribute, currentRefinement, items, refine }) => (
   </SearchRefinementListRefinements>
 );
 
-const CustomRefinementList = connectRefinementList(RefinementList);
-
-const SearchRefinementList = (props) => {
-  const { showHideLabel, operator, ...restProps } = props;
-  return (
+const SearchRefinementList = ({ showHideLabel, operator, items, ...restProps }) => (
+  items.length > 0 && (
     <ShowHide isFieldset label={showHideLabel}>
-      <CustomRefinementList
+      <RefinementList
+        items={items}
         operator={operator}
         {...restProps}
       />
     </ShowHide>
-  );
-};
+  )
+);
 
 SearchRefinementList.propTypes = {
   /** Algolia attribute that is used to pull refinement values. */
@@ -115,4 +113,4 @@ SearchRefinementList.defaultProps = {
   transformItems: null,
 };
 
-export default SearchRefinementList;
+export default connectRefinementList(SearchRefinementList);


### PR DESCRIPTION
* Memoize the `StandardCard` here vs jarvis
* Wrap the refinement list with a connected component to avoid render when there are no `items`, which means there's nothing to render