### PR TITLE
adjust spacing of stickers for cards with no image

### DIFF
--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -29,6 +29,7 @@ const ImageWrapper = styled.div`
   width: 100%;
 
   .no-image & {
+    background-color: transparent;
     display: flex;
     align-items: center;
     margin-bottom: ${spacing.xxsm};

--- a/src/components/Cards/shared/Sticker/index.js
+++ b/src/components/Cards/shared/Sticker/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import breakpoint from 'styled-components-breakpoint';
 import styled from 'styled-components';
 import { color, font, fontSize, letterSpacing, spacing } from '../../../../styles';
 import { Collection, VideoPlay } from '../../../DesignTokens/Icon';
@@ -28,6 +29,12 @@ const StyledSticker = styled.span`
     height: 1rem;
     max-height: 60%;
   }
+
+  ${breakpoint('xs', 'lg')`
+    &:not(:first-of-type) {
+      display: none;
+    }
+  `}
 `;
 
 const determineIconType = (contentType) => {


### PR DESCRIPTION
* provide a little bit of space and wrap stickers. This seems to work nicely for stickers that are on one line and multiple lines
* set background image wrapper to transparent when no image