### PR TITLE
use href vs siteKey in standard card memo check in case idx changed on href

### DIFF
--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -199,6 +199,7 @@ StandardCard.propTypes = {
   ctaUrl: PropTypes.string,
   displayCommentCount: PropTypes.bool,
   displayLockIcon: PropTypes.bool,
+  href: PropTypes.string.isRequired,
   imageAlt: PropTypes.string,
   imageUrl: PropTypes.string,
   isFavorited: PropTypes.bool,
@@ -208,7 +209,6 @@ StandardCard.propTypes = {
   siteKeyFavorites: PropTypes.oneOf(['atk', 'cco', 'cio']),
   stickers: PropTypes.array,
   title: PropTypes.string.isRequired,
-  href: PropTypes.string.isRequired,
 };
 
 StandardCard.defaultProps = {
@@ -228,7 +228,7 @@ StandardCard.defaultProps = {
   stickers: [],
 };
 
-export default React.memo(StandardCard, (prevProps, nextProps) => (
-  prevProps.objectId === nextProps.objectId
-  && prevProps.siteKey === nextProps.siteKey
+export default React.memo(StandardCard, (prev, next) => (
+  prev.objectId === next.objectId
+  && prev.href === next.href
 ));


### PR DESCRIPTION
* corresponding `jarvis` change sets the `href` with a `ref=new_search_experience_${idx}` which indicates the position in the grid. This change allows the card to update when the position in the index changes. This is valuable when a card goes from position 24 to position 5 after a filter change. This change will still take into account `siteKey`, so we can remove that check.