### PR TITLE
standard card tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint-plugin-react-hooks": "^3.0.0",
     "eslint-plugin-standard": "^4.0.1",
     "jest": "24.9.0",
+    "jest-styled-components": "^7.0.2",
     "react-test-renderer": "^16.12.0",
     "watch": "^1.0.2"
   },

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -48,7 +48,7 @@ const TitleWrapper = styled.div`
   padding-top: ${spacing.xsm};
 `;
 
-const StyledTitle = styled(Title)`
+export const StyledTitle = styled(Title)`
   transition: color 0.2s ease;
 
   &:hover {
@@ -56,12 +56,12 @@ const StyledTitle = styled(Title)`
   }
 `;
 
-const StyledFavoriteButton = styled(FavoriteButton)`
+export const StyledFavoriteButton = styled(FavoriteButton)`
   flex-shrink: 0;
   margin-top: ${spacing.xxsm};
 `;
 
-const StickerGroup = styled.div`
+export const StickerGroup = styled.div`
   display: flex;
   position: absolute;
   bottom: 0;
@@ -76,7 +76,7 @@ const StickerGroup = styled.div`
 `;
 
 const stickerHeightMobile = '1.2rem';
-const StyledSticker = styled(Sticker)`
+export const StyledSticker = styled(Sticker)`
   ${breakpoint('xs', 'lg')`
     border-radius: 0.5rem;
     line-height: ${stickerHeightMobile};
@@ -85,7 +85,7 @@ const StyledSticker = styled(Sticker)`
   `}
 `;
 
-const StyledBadge = styled(Badge)`
+export const StyledBadge = styled(Badge)`
   position: absolute;
   top: ${spacing.xsm};
   left: ${spacing.xsm};

--- a/src/components/Cards/__tests__/StandardCard.spec.js
+++ b/src/components/Cards/__tests__/StandardCard.spec.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import TestRenderer from 'react-test-renderer';
+import 'jest-styled-components';
+
+import StandardCard, {
+  StyledBadge,
+  StyledFavoriteButton,
+  StickerGroup,
+  StyledSticker,
+  StyledTitle,
+} from '../StandardCard';
+import Attributions from '../shared/Attributions';
+import CtaLink from '../shared/CtaLink';
+import Image from '../shared/Image';
+import breakpoints from '../../../styles/breakpoints';
+
+const baseRecipe = {
+  className: null,
+  commentCount: 1,
+  contentType: 'recipe',
+  contentTypeFormatted: 'Recipe',
+  ctaText: null,
+  ctaUrl: null,
+  displayCookbook: false,
+  displayCommentCount: true,
+  displayFavoritesButton: false,
+  displayLockIcon: true,
+  stickers: [{ text: 'new', type: 'priority' }],
+  imageAlt: ' ',
+  imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/ar_1:1,c_fill,dpr_2.0,f_auto,fl_lossy,g_faces,h_200,q_auto:low/22391_sfs-chocolate-crinkle-cookies-35',
+  isFavorited: false,
+  objectId: 'recipe_8125',
+  onClick: null,
+  shopPrices: null,
+  siteKey: 'atk',
+  siteKeyFavorites: null,
+  title: 'Chocolate Crinkle Cookies',
+  href: 'https://www.americastestkitchen.com/recipes/8125-chocolate-crinkle-cookies?incode=MASAD00L0&ref=new_search_experience_3',
+};
+
+const baseTasteTest = {
+  className: null,
+  commentCount: 1,
+  contentType: 'taste_test',
+  contentTypeFormatted: 'Taste Test',
+  ctaText: 'Buy The Winner',
+  ctaUrl: 'http://www.amazon.com/dp/B00N9TX628/?tag=atksearchresult-20',
+  displayCookbook: false,
+  displayCommentCount: true,
+  displayFavoritesButton: false,
+  displayLockIcon: true,
+  stickers: [{ text: '6 tested', type: 'editorial' }],
+  imageAlt: ' ',
+  imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/ar_1:1,c_fill,dpr_2.0,f_auto,fl_lossy,g_faces,h_200,q_auto:low/26529_sil-baking-powder-argo-double-acting-baking-powder',
+  isFavorited: false,
+  objectId: 'taste_test_1644',
+  onClick: null,
+  shopPrices: null,
+  siteKey: 'atk',
+  siteKeyFavorites: null,
+  title: 'Baking Powder',
+  href: 'https://www-staging.americastestkitchen.com/taste_tests/1644-baking-powder?incode=MASAD00L0&ref=new_search_experience_1',
+};
+
+
+describe('StandardCard component', () => {
+  const componentSetup = (props) => {
+    const testRenderer = TestRenderer.create(
+      <ThemeProvider
+        theme={{ breakpoints }}
+      >
+        <StandardCard
+          {...props}
+        />
+      </ThemeProvider>,
+    );
+    return testRenderer.root;
+  };
+
+  it('Renders with an image', () => {
+    const testInstance = componentSetup(baseRecipe);
+    expect(testInstance.findByType(Image));
+  });
+
+  it('Renders without an image', () => {
+    const testInstance = componentSetup({
+      ...baseRecipe,
+      imageUrl: null,
+    });
+    expect(testInstance.findAllByType(Image).length).toBe(0);
+  });
+
+  it('Renders with a correct site badge', () => {
+    const testInstance = componentSetup(baseRecipe);
+    expect(testInstance.findByType(StyledBadge).props.type).toBe(baseRecipe.siteKey);
+  });
+
+  it('Renders with a "new" sticker', () => {
+    const testInstance = componentSetup(baseRecipe);
+    expect(testInstance.findByType(StyledSticker).props.type).toBe('priority');
+  });
+
+  it('Renders without stickers', () => {
+    const testInstance = componentSetup({
+      ...baseRecipe,
+      stickers: null,
+    });
+    expect(testInstance.findAllByType(StickerGroup).length).toBe(0);
+  });
+
+  it('Renders with a title', () => {
+    const testInstance = componentSetup(baseRecipe);
+    expect(testInstance.findByType(StyledTitle).props.title).toBe(baseRecipe.title);
+  });
+
+  it('Renders with a comment count', () => {
+    const testInstance = componentSetup(baseRecipe);
+    expect(testInstance.findByType(Attributions).props.commentCount).toBe(baseRecipe.commentCount);
+  });
+
+  it('Renders fallback content type attribution', () => {
+    const testInstance = componentSetup({
+      ...baseRecipe,
+      contentTypeFormatted: null,
+    });
+    expect(testInstance.findByType(Attributions).props.contentType).toBe(baseRecipe.contentType);
+  });
+
+  it('Renders without a FavoriteButton', () => {
+    const testInstance = componentSetup(baseRecipe);
+    expect(testInstance.findAllByType(StyledFavoriteButton).length).toBe(0);
+  });
+
+  it('Renders with a FavoriteButton', () => {
+    const testInstance = componentSetup({
+      ...baseRecipe,
+      displayFavoritesButton: true,
+      siteKeyFavorites: 'atk',
+    });
+    expect(testInstance.findByType(StyledFavoriteButton));
+  });
+
+  it('Renders with a CTA Link for a Taste Test', () => {
+    const testInstance = componentSetup(baseTasteTest);
+    expect(testInstance.findByType(CtaLink));
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8960,6 +8960,13 @@ jest-snapshot@^24.9.0:
     pretty-format "^24.9.0"
     semver "^6.2.0"
 
+jest-styled-components@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-7.0.2.tgz#b7711871ea74a04491b12bad123fa35cc65a2a80"
+  integrity sha512-i1Qke8Jfgx0Why31q74ohVj9S2FmMLUE8bNRSoK4DgiurKkXG6HC4NPhcOLAz6VpVd9wXkPn81hOt4aAQedqsA==
+  dependencies:
+    css "^2.2.4"
+
 jest-util@^24.0.0, jest-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.9.0.tgz#7396814e48536d2e85a37de3e4c431d7cb140162"


### PR DESCRIPTION
add some tests for the standard card

NOTE: to get this working locally, you will have to follow the updated README directions. We now need to link `react-test-renderer` within `mise-ui` and within `jarvis` we need to link `react-test-renderer` to the jarvis `react`

You'll have to run `yarn` and then start over with the `npm link` commands