### PR TITLE
specify card link hover style

### DIFF
--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -17,6 +17,10 @@ const StyledStandardCard = styled.article`
   width: 16.2rem;
   color: ${color.eclipse};
 
+  a.standard-card__anchor:hover {
+    color: ${color.eclipse};
+  }
+
   ${breakpoint('lg')`
     padding-bottom: ${spacing.lg};
     width: 27.2rem;


### PR DESCRIPTION
Since there is no explicit hover state on the wrapper card link in Mise, Jarvis's base link styles are applied to the Card when hovered