### PR TITLE
basic Carousel with markdown docs

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,5 +8,6 @@ module.exports = {
     '@storybook/addon-knobs/register',
     '@storybook/addon-viewport/register',
     '@whitespace/storybook-addon-html/register',
+    '@storybook/addon-notes/register',
   ],
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,11 +4,12 @@ import { createGlobalStyle, ThemeProvider } from 'styled-components';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { withHTML } from '@whitespace/storybook-addon-html/react';
 import { breakpoints } from '../src/styles';
+import carousel from '../src/styles/carousel';
 import globalStyles from '../src/styles/global';
 
 const theme = { breakpoints };
 
-const GlobalStyle = createGlobalStyle`${globalStyles}`;
+const GlobalStyle = createGlobalStyle`${globalStyles}${carousel}`;
 
 addDecorator(
   withHTML({

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "algoliasearch": "^4.0.3",
+    "flickity": "^2.2.1",
     "lodash.memoize": "^4.1.2",
     "lodash.orderby": "^4.6.0",
     "prop-types": "^15.7.2",
@@ -58,6 +59,7 @@
     "@storybook/addon-docs": "^5.3.13",
     "@storybook/addon-knobs": "^5.3.13",
     "@storybook/addon-links": "^5.3.13",
+    "@storybook/addon-notes": "^5.3.19",
     "@storybook/addon-viewport": "^5.3.13",
     "@storybook/addons": "^5.3.13",
     "@storybook/preset-create-react-app": "^1.5.2",

--- a/src/components/Cards/shared/ProgressBar/index.js
+++ b/src/components/Cards/shared/ProgressBar/index.js
@@ -12,7 +12,7 @@ const StyledProgressBar = styled.div`
     position: relative;
     height: 6px;
     width: 16.5rem;
-    
+
     &::before {
       background-color: ${color.white};
       content: '';
@@ -36,11 +36,12 @@ const ProgressBar = ({
 
 ProgressBar.propTypes = {
   progress: PropTypes.number,
-  videoId: PropTypes.string.isRequired,
+  videoId: PropTypes.string,
 };
 
 ProgressBar.defaultProps = {
   progress: 0,
+  videoId: undefined,
 };
 
 export default ProgressBar;

--- a/src/components/Carousel/Carousel.md
+++ b/src/components/Carousel/Carousel.md
@@ -1,0 +1,38 @@
+# Mise-UI `Carousel` component
+
+### Do not implement this Carousel directly from `espresso` or `jarvis`.
+
+The `mise-ui` Carousel component wraps a Flickity carousel. By itself
+the `Carousel` component will not render properly as each Carousel
+instance needs to be styled based on the contents of the carousel.
+
+In practice, `Carousel` should be imported into a wrapping component, which includes styles for the desired UI presentation.
+
+For instance, the Carousel instance depicted in this documentation is
+wrapped by a styled-components instance which styles each of the
+`.carousel-item` elements within the carousel. This style is required
+for Flickity know how to render each item.
+
+```
+const images = new Array(10)
+  .fill('http://placeimg.com/250/250/nature')
+  .map((i, idx) => `${i}?i=${idx}`);
+
+const DefaultCarouselWrapper = styled.div`
+  .carousel-cell {
+    margin-right: 1rem;
+    min-height: 25rem;
+    width: 25rem;
+    max-width: 100vw;
+  }
+`;
+
+export const Default = () => (
+  <DefaultCarouselWrapper>
+    <Carousel
+      items={images}
+      renderItem={(i) => <img src={i} alt=" " />}
+    />
+  </DefaultCarouselWrapper>
+);
+```

--- a/src/components/Carousel/Carousel.stories.js
+++ b/src/components/Carousel/Carousel.stories.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs/react';
+
+import Carousel from './index';
+import CarouselNotes from './Carousel.md';
+
+export default {
+  title: 'Components|Carousel',
+  component: Carousel,
+  decorators: [withKnobs],
+  parameters: {
+    notes: CarouselNotes,
+  },
+};
+
+const images = new Array(10)
+  .fill('http://placeimg.com/250/250/nature')
+  .map((i, idx) => `${i}?i=${idx}`);
+
+const DefaultCarouselWrapper = styled.div`
+  .carousel-cell {
+    margin-right: 1rem;
+    min-height: 25rem;
+    width: 25rem;
+    max-width: 100vw;
+  }
+`;
+
+export const Default = () => (
+  <DefaultCarouselWrapper>
+    <Carousel
+      items={images}
+      renderItem={(i) => <img src={i} alt=" " />}
+      options={{
+        cellAlign: select('Cell Alignment', ['center', 'left', 'right'], 'center'),
+        navigationDots: boolean('Navigation Dots', true),
+        slideshow: boolean('Slideshow', true),
+        wrapAround: boolean('Wraparound', true),
+      }}
+    />
+  </DefaultCarouselWrapper>
+);

--- a/src/components/Carousel/__tests__/Carousel.spec.js
+++ b/src/components/Carousel/__tests__/Carousel.spec.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import 'jest-styled-components';
+
+import breakpoints from '../../../styles/breakpoints';
+import Carousel from '../index';
+
+const images = new Array(5)
+  .fill('http://placeimg.com/250/250/nature')
+  .map((i, idx) => `${i}?i=${idx}`);
+
+describe('Carousel component should', () => {
+  const renderComponent = () => (
+    render(
+      <ThemeProvider theme={{ breakpoints }}>
+        <Carousel
+          items={images}
+          renderItem={i => <img data-testid={i} src={i} alt=" " />}
+        />
+      </ThemeProvider>,
+    )
+  );
+
+  it('render all slides', () => {
+    renderComponent();
+    expect(screen.getByTestId(images[0]));
+    expect(screen.getByTestId(images[1]));
+    expect(screen.getByTestId(images[2]));
+    expect(screen.getByTestId(images[3]));
+    expect(screen.getByTestId(images[4]));
+  });
+});

--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -1,0 +1,183 @@
+import PropTypes from 'prop-types';
+import React, { useEffect, useRef } from 'react';
+import styled, { css } from 'styled-components';
+
+import { withThemes } from '../../styles';
+
+const CarouselTheme = {
+  default: css`
+    width: 100%;
+
+    img {
+      display: block;
+    }
+
+    &.flickity-enabled {
+      .carousel-cell:not(.is-selected) {
+        opacity: 0.3;
+      }
+    }
+
+    &:not(.flickity-enabled) {
+      overflow: hidden;
+
+      .slideshow & {
+        .carousel-cell {
+          display: flex;
+          margin: 0 auto;
+        }
+      }
+    }
+  `,
+};
+
+const CarouselWrapper = styled.div`
+  position: relative;
+`;
+
+const CarouselEl = styled.div.attrs(props => ({
+  className: [props.className, 'carousel'].join(' '),
+}))`${withThemes(CarouselTheme)}`;
+
+// IOS13 bug fix
+// https://github.com/metafizzy/flickity/issues/959
+// https://gist.github.com/bakura10/b0647ef412eb7757fa6f0d2c74c1f145
+function temporaryCarouselFix() {
+  let touchingCarousel = false;
+  let touchStartCoords;
+
+  document.body.addEventListener('touchstart', (e) => {
+    touchingCarousel = Boolean(e.target.closest('.flickity-slider'));
+    if (!touchingCarousel) return;
+
+    touchStartCoords = {
+      x: e.touches[0].pageX,
+      y: e.touches[0].pageY,
+    };
+  });
+
+  document.body.addEventListener('touchmove', (e) => {
+    if (!(touchingCarousel && e.cancelable)) return;
+    const moveVector = {
+      x: e.touches[0].pageX - touchStartCoords.x,
+      y: e.touches[0].pageY - touchStartCoords.y,
+    };
+    if (Math.abs(moveVector.x) > 7) e.preventDefault();
+  }, { passive: false });
+}
+
+function getFlickityInstance(el, options) {
+  const {
+    arrowShape,
+    cellAlign = 'center',
+    slideshow,
+    navigationArrows,
+    navigationDots,
+    wrapAround,
+  } = options;
+  const isPhone = window.innerWidth <= 768 || window.innerHeight <= 450;
+  const groupCells = slideshow ? false : '100%';
+  const cOptions = {
+    cellAlign,
+    dragThreshold: 10,
+    groupCells,
+    prevNextButtons: navigationArrows,
+    pageDots: navigationDots,
+    wrapAround,
+  };
+  if (isPhone) {
+    temporaryCarouselFix();
+    cOptions.freeScroll = true;
+    cOptions.freeScrollFriction = 0.085;
+  } else {
+    cOptions.friction = 0.7;
+    cOptions.selectedAttraction = 0.08;
+  }
+  if (arrowShape) cOptions.arrowShape = arrowShape;
+  const Flickity = require('flickity'); // eslint-disable-line
+  return new Flickity( // eslint-disable-line
+    el,
+    cOptions,
+  );
+}
+
+const defaultOptions = {
+  arrowShape: { x0: 10, x1: 60, y1: 50, x2: 60, y2: 40, x3: 60 },
+  cellAlign: 'center',
+  navigationArrows: true,
+  navigationDots: true,
+  slideshow: false,
+  wrapAround: false,
+};
+
+const Carousel = ({ className, items, options, renderItem }) => {
+  const elRef = useRef(null);
+  const flktyRef = useRef();
+  const opts = { ...defaultOptions, ...options };
+  const { slideshow } = opts;
+
+  useEffect(() => {
+    if (flktyRef.current) flktyRef.current.destroy();
+    if (items.length > 1 && elRef?.current) {
+      const flkty = getFlickityInstance(elRef.current, opts);
+      if (flkty.slides.length === 1) flkty.destroy();
+      else flktyRef.current = flkty;
+    }
+    return () => flktyRef.current?.destroy();
+  }, [
+    items,
+    opts.cellAlign,
+    opts.navigationDots,
+    opts.slideshow,
+    opts.wrapAround,
+  ]);
+
+  return (
+    <CarouselWrapper
+      className={`carousel-wrapper${slideshow ? ' slideshow' : ''}`}
+    >
+      <CarouselEl
+        className={className}
+        ref={elRef}
+      >
+        {items.map((item, idx) => (
+          <div
+            className="carousel-cell"
+            key={`carousel-cell-${item.id}-${idx}`}
+          >
+            {renderItem(item, idx)}
+          </div>
+        ))}
+      </CarouselEl>
+    </CarouselWrapper>
+  );
+};
+
+Carousel.propTypes = {
+  /** Additional classname */
+  className: PropTypes.string,
+  /** List of items for the carousel */
+  items: PropTypes.array.isRequired,
+  options: PropTypes.shape({
+    /** Change shape of arrows on carousel */
+    arrowShape: PropTypes.object,
+    /** Change cell alignment inside carousel */
+    cellAlign: PropTypes.string,
+    /** Include prev/next navigation buttons */
+    navigationArrows: PropTypes.bool,
+    /** Include navigation dots */
+    navigationDots: PropTypes.bool,
+    /** Show one item at a time */
+    slideshow: PropTypes.bool,
+    /** Enables infinite scrolling in carousel */
+    wrapAround: PropTypes.bool,
+  }),
+  renderItem: PropTypes.func.isRequired,
+};
+
+Carousel.defaultProps = {
+  className: undefined,
+  options: {},
+};
+
+export default Carousel;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import Accordion from './components/Accordion';
 import Badge from './components/Badge';
 import breakpoints from './styles/breakpoints';
 import Button from './components/Button';
+import carousel from './styles/carousel';
 import ClearRefinements from './components/Algolia/shared/ClearRefinements';
 import CurrentRefinements from './components/Algolia/shared/CurrentRefinements';
 import FilterButton from './components/FilterButton';
@@ -22,6 +23,7 @@ export {
   Badge,
   breakpoints,
   Button,
+  carousel,
   ClearRefinements,
   CurrentRefinements,
   FilterButton,

--- a/src/styles/carousel.js
+++ b/src/styles/carousel.js
@@ -1,0 +1,156 @@
+import { css } from 'styled-components';
+
+export default css`
+  /* START - CUSTOM ATK GLOBAL STYLES */
+  .flickity-button {
+    background: none;
+
+    &:hover {
+      background: none;
+    }
+  }
+
+  .flickity-page-dots {
+    bottom: -15px;
+  }
+  /* end - CUSTOM ATK GLOBAL STYLES */
+
+  /*! Flickity v2.2.1
+  https://flickity.metafizzy.co
+  ---------------------------------------------- */
+
+  .flickity-enabled {
+    position: relative;
+  }
+
+  .flickity-enabled:focus { outline: none; }
+
+  .flickity-viewport {
+    overflow: hidden;
+    position: relative;
+    height: 100%;
+  }
+
+  .flickity-slider {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+  }
+
+  /* draggable */
+
+  .flickity-enabled.is-draggable {
+    -webkit-tap-highlight-color: transparent;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+  }
+
+  .flickity-enabled.is-draggable .flickity-viewport {
+    cursor: move;
+    cursor: -webkit-grab;
+    cursor: grab;
+  }
+
+  .flickity-enabled.is-draggable .flickity-viewport.is-pointer-down {
+    cursor: -webkit-grabbing;
+    cursor: grabbing;
+  }
+
+  /* ---- flickity-button ---- */
+
+  .flickity-button {
+    position: absolute;
+    background: hsla(0, 0%, 100%, 0.75);
+    border: none;
+    color: #333;
+  }
+
+  .flickity-button:hover {
+    background: white;
+    cursor: pointer;
+  }
+
+  .flickity-button:focus {
+    outline: none;
+    box-shadow: 0 0 0 5px #19F;
+  }
+
+  .flickity-button:active {
+    opacity: 0.6;
+  }
+
+  .flickity-button:disabled {
+    opacity: 0.3;
+    cursor: auto;
+    /* prevent disabled button from capturing pointer up event. #716 */
+    pointer-events: none;
+  }
+
+  .flickity-button-icon {
+    fill: currentColor;
+  }
+
+  /* ---- previous/next buttons ---- */
+
+  .flickity-prev-next-button {
+    top: 50%;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    /* vertically center */
+    transform: translateY(-50%);
+  }
+
+  .flickity-prev-next-button.previous { left: 10px; }
+  .flickity-prev-next-button.next { right: 10px; }
+  /* right to left */
+  .flickity-rtl .flickity-prev-next-button.previous {
+    left: auto;
+    right: 10px;
+  }
+  .flickity-rtl .flickity-prev-next-button.next {
+    right: auto;
+    left: 10px;
+  }
+
+  .flickity-prev-next-button .flickity-button-icon {
+    position: absolute;
+    left: 20%;
+    top: 20%;
+    width: 60%;
+    height: 60%;
+  }
+
+  /* ---- page dots ---- */
+
+  .flickity-page-dots {
+    position: absolute;
+    width: 100%;
+    bottom: -25px;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    text-align: center;
+    line-height: 1;
+  }
+
+  .flickity-rtl .flickity-page-dots { direction: rtl; }
+
+  .flickity-page-dots .dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    margin: 0 8px;
+    background: #333;
+    border-radius: 50%;
+    opacity: 0.25;
+    cursor: pointer;
+  }
+
+  .flickity-page-dots .dot.is-selected {
+    opacity: 1;
+  }
+
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,6 +2143,25 @@
     qs "^6.6.0"
     ts-dedent "^1.1.0"
 
+"@storybook/addon-notes@^5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-notes/-/addon-notes-5.3.19.tgz#facd20dcea37e9eebb94c087012502c886d66533"
+  integrity sha512-9dkUY5bPO/nux6zIXtE4h27AXgqz1Pogrbg7x0BwYWFdoMh7A8AWcnREfkjiPtrB/XGInlNRPqkU0KKk6tMi/w==
+  dependencies:
+    "@storybook/addons" "5.3.19"
+    "@storybook/api" "5.3.19"
+    "@storybook/client-logger" "5.3.19"
+    "@storybook/components" "5.3.19"
+    "@storybook/core-events" "5.3.19"
+    "@storybook/router" "5.3.19"
+    "@storybook/theming" "5.3.19"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    markdown-to-jsx "^6.10.3"
+    memoizerific "^1.11.3"
+    prop-types "^15.7.2"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-viewport@^5.3.13":
   version "5.3.17"
   resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-5.3.17.tgz#ef7b4bf8a58291940938828c6eedd07984f75e66"
@@ -2169,6 +2188,19 @@
     "@storybook/channels" "5.3.17"
     "@storybook/client-logger" "5.3.17"
     "@storybook/core-events" "5.3.17"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    util-deprecate "^1.0.2"
+
+"@storybook/addons@5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.3.19.tgz#3a7010697afd6df9a41b8c8a7351d9a06ff490a4"
+  integrity sha512-Ky/k22p6i6FVNvs1VhuFyGvYJdcp+FgXqFgnPyY/OXJW/vPDapdElpTpHJZLFI9I2FQBDcygBPU5RXkumQ+KUQ==
+  dependencies:
+    "@storybook/api" "5.3.19"
+    "@storybook/channels" "5.3.19"
+    "@storybook/client-logger" "5.3.19"
+    "@storybook/core-events" "5.3.19"
     core-js "^3.0.1"
     global "^4.3.2"
     util-deprecate "^1.0.2"
@@ -2238,6 +2270,32 @@
     telejson "^3.2.0"
     util-deprecate "^1.0.2"
 
+"@storybook/api@5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-5.3.19.tgz#77f15e9e2eee59fe1ddeaba1ef39bc34713a6297"
+  integrity sha512-U/VzDvhNCPmw2igvJYNNM+uwJCL+3teiL6JmuoL4/cmcqhI6IqqG9dZmMP1egoCd19wXEP7rnAfB/VcYVg41dQ==
+  dependencies:
+    "@reach/router" "^1.2.1"
+    "@storybook/channels" "5.3.19"
+    "@storybook/client-logger" "5.3.19"
+    "@storybook/core-events" "5.3.19"
+    "@storybook/csf" "0.0.1"
+    "@storybook/router" "5.3.19"
+    "@storybook/theming" "5.3.19"
+    "@types/reach__router" "^1.2.3"
+    core-js "^3.0.1"
+    fast-deep-equal "^2.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    prop-types "^15.6.2"
+    react "^16.8.3"
+    semver "^6.0.0"
+    shallow-equal "^1.1.0"
+    store2 "^2.7.1"
+    telejson "^3.2.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/channel-postmessage@5.3.17":
   version "5.3.17"
   resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-5.3.17.tgz#807b6316cd0e52d9f27363d5092ad1cd896b694c"
@@ -2260,6 +2318,13 @@
   version "5.3.18"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.3.18.tgz#490c9eaa8292b0571c0f665052b12addf7c35f21"
   integrity sha512-scP/6td/BJSEOgfN+qaYGDf3E793xye7tIw6W+sYqwg+xdMFO39wVXgVZNpQL6sLEwpJZTaPywCjC6p6ksErqQ==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/channels@5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.3.19.tgz#65ad7cd19d70aa5eabbb2e5e39ceef5e510bcb7f"
+  integrity sha512-38seaeyshRGotTEZJppyYMg/Vx2zRKgFv1L6uGqkJT0LYoNSYtJhsiNFCJ2/KUJu2chAJ/j8h80bpVBVLQ/+WA==
   dependencies:
     core-js "^3.0.1"
 
@@ -2300,6 +2365,13 @@
   dependencies:
     core-js "^3.0.1"
 
+"@storybook/client-logger@5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.3.19.tgz#fbbd186e82102eaca1d6a5cca640271cae862921"
+  integrity sha512-nHftT9Ow71YgAd2/tsu79kwKk30mPuE0sGRRUHZVyCRciGFQweKNOS/6xi2Aq+WwBNNjPKNlbgxwRt1yKe1Vkg==
+  dependencies:
+    core-js "^3.0.1"
+
 "@storybook/components@5.3.17":
   version "5.3.17"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-5.3.17.tgz#287430fc9c5f59b1d3590b50b3c7688355b22639"
@@ -2313,6 +2385,33 @@
     global "^4.3.2"
     lodash "^4.17.15"
     markdown-to-jsx "^6.9.1"
+    memoizerific "^1.11.3"
+    polished "^3.3.1"
+    popper.js "^1.14.7"
+    prop-types "^15.7.2"
+    react "^16.8.3"
+    react-dom "^16.8.3"
+    react-focus-lock "^2.1.0"
+    react-helmet-async "^1.0.2"
+    react-popper-tooltip "^2.8.3"
+    react-syntax-highlighter "^11.0.2"
+    react-textarea-autosize "^7.1.0"
+    simplebar-react "^1.0.0-alpha.6"
+    ts-dedent "^1.1.0"
+
+"@storybook/components@5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-5.3.19.tgz#aac1f9eea1247cc85bd93b10fca803876fb84a6b"
+  integrity sha512-3g23/+ktlocaHLJKISu9Neu3XKa6aYP2ctDYkRtGchSB0Q55hQsUVGO+BEVuT7Pk2D59mVCxboBjxcRoPUY4pw==
+  dependencies:
+    "@storybook/client-logger" "5.3.19"
+    "@storybook/theming" "5.3.19"
+    "@types/react-syntax-highlighter" "11.0.4"
+    "@types/react-textarea-autosize" "^4.3.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    markdown-to-jsx "^6.11.4"
     memoizerific "^1.11.3"
     polished "^3.3.1"
     popper.js "^1.14.7"
@@ -2365,6 +2464,13 @@
   version "5.3.18"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.18.tgz#e5d335f8a2c7dd46502b8f505006f1e111b46d49"
   integrity sha512-uQ6NYJ5WODXK8DJ7m8y3yUAtWB3n+6XtYztjY+tdkCsLYvTYDXNS+epV+f5Hu9+gB+/Dm+b5Su4jDD+LZB2QWA==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/core-events@5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.19.tgz#18020cd52e0d8ef0973a8e9622a10d5f99796f79"
+  integrity sha512-lh78ySqMS7pDdMJAQAe35d1I/I4yPTqp09Cq0YIYOxx9BQZhah4DZTV1QIZt22H5p2lPb5MWLkWSxBaexZnz8A==
   dependencies:
     core-js "^3.0.1"
 
@@ -2540,6 +2646,21 @@
     qs "^6.6.0"
     util-deprecate "^1.0.2"
 
+"@storybook/router@5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-5.3.19.tgz#0f783b85658f99e4007f74347ad7ef17dbf7fc3a"
+  integrity sha512-yNClpuP7BXQlBTRf6Ggle3/R349/k6kvI5Aim4jf6X/2cFVg2pzBXDAF41imNm9PcvdxwabQLm6I48p7OvKr/w==
+  dependencies:
+    "@reach/router" "^1.2.1"
+    "@storybook/csf" "0.0.1"
+    "@types/reach__router" "^1.2.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/source-loader@5.3.17":
   version "5.3.17"
   resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-5.3.17.tgz#f407aed52bc758b2c0c760d28b4525b8337e6944"
@@ -2582,6 +2703,24 @@
     "@emotion/core" "^10.0.20"
     "@emotion/styled" "^10.0.17"
     "@storybook/client-logger" "5.3.18"
+    core-js "^3.0.1"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.19"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    polished "^3.3.1"
+    prop-types "^15.7.2"
+    resolve-from "^5.0.0"
+    ts-dedent "^1.1.0"
+
+"@storybook/theming@5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.3.19.tgz#177d9819bd64f7a1a6ea2f1920ffa5baf9a5f467"
+  integrity sha512-ecG+Rq3hc1GOzKHamYnD4wZ0PEP9nNg0mXbC3RhbxfHj+pMMCWWmx9B2Uu75SL1PTT8WcfkFO0hU/0IO84Pzlg==
+  dependencies:
+    "@emotion/core" "^10.0.20"
+    "@emotion/styled" "^10.0.17"
+    "@storybook/client-logger" "5.3.19"
     core-js "^3.0.1"
     deep-object-diff "^1.1.0"
     emotion-theming "^10.0.19"
@@ -5919,6 +6058,11 @@ des.js@^1.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
+desandro-matches-selector@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/desandro-matches-selector/-/desandro-matches-selector-2.0.2.tgz#717beed4dc13e7d8f3762f707a6d58a6774218e1"
+  integrity sha1-cXvu1NwT59jzdi9wem1YpndCGOE=
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -6716,6 +6860,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+ev-emitter@^1.0.1, ev-emitter@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ev-emitter/-/ev-emitter-1.1.1.tgz#8f18b0ce5c76a5d18017f71c0a795c65b9138f2a"
+  integrity sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q==
+
 eventemitter3@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
@@ -7134,6 +7283,13 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+fizzy-ui-utils@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fizzy-ui-utils/-/fizzy-ui-utils-2.0.7.tgz#7df45dcc4eb374a08b65d39bb9a4beedf7330505"
+  integrity sha512-CZXDVXQ1If3/r8s0T+v+qVeMshhfcuq0rqIFgJnrtd+Bu8GmDmqMjntjUePypVtjHXKJ6V4sw9zeyox34n9aCg==
+  dependencies:
+    desandro-matches-selector "^2.0.0"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -7152,6 +7308,18 @@ flatten@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
+
+flickity@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/flickity/-/flickity-2.2.1.tgz#81126e3d656cb54577358a5f959ffdbda088e670"
+  integrity sha512-fCZJGNqabgDrIhaUBqt2ydE8c5V6iiB3KQAf6dH3Z45MoDUm7g6+uZmteN0aLV9pzVItNqCbfOJQjsJM/rHuSA==
+  dependencies:
+    desandro-matches-selector "^2.0.0"
+    ev-emitter "^1.1.1"
+    fizzy-ui-utils "^2.0.7"
+    get-size "^2.0.3"
+    unidragger "^2.3.0"
+    unipointer "^2.3.0"
 
 flow-parser@0.*:
   version "0.120.1"
@@ -7425,6 +7593,11 @@ get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
   integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
+
+get-size@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/get-size/-/get-size-2.0.3.tgz#54a1d0256b20ea7ac646516756202769941ad2ef"
+  integrity sha512-lXNzT/h/dTjTxRbm9BXb+SGxxzkm97h/PCIKtlN/CBCxxmkkIVV21udumMS93MuVTDX583gqc94v3RjuHmI+2Q==
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -9873,6 +10046,14 @@ markdown-escapes@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
+
+markdown-to-jsx@^6.10.3, markdown-to-jsx@^6.11.4:
+  version "6.11.4"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz#b4528b1ab668aef7fe61c1535c27e837819392c5"
+  integrity sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==
+  dependencies:
+    prop-types "^15.6.2"
+    unquote "^1.1.0"
 
 markdown-to-jsx@^6.9.1, markdown-to-jsx@^6.9.3:
   version "6.11.0"
@@ -12539,6 +12720,11 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -14721,6 +14907,13 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
 
+unidragger@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/unidragger/-/unidragger-2.3.1.tgz#2e8c34feff61affa96dc895234ddfc1ea4ec7515"
+  integrity sha512-u+IgG7AG0MXJTKcdzAIYxCm+W5FcnA9M28203Awl6jIcE3/+9OtEyUX4Wv64y7XNKEVRKPot52IV4V6x7FlF5Q==
+  dependencies:
+    unipointer "^2.3.0"
+
 unified@8.4.2:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-8.4.2.tgz#13ad58b4a437faa2751a4a4c6a16f680c500fff1"
@@ -14741,6 +14934,13 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
+
+unipointer@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/unipointer/-/unipointer-2.3.0.tgz#ba0dc462ce31c2a88e80810e19c3bae0ce47ed9f"
+  integrity sha512-m85sAoELCZhogI1owtJV3Dva7GxkHk2lI7A0otw3o0OwCuC/Q9gi7ehddigEYIAYbhkqNdri+dU1QQkrcBvirQ==
+  dependencies:
+    ev-emitter "^1.0.1"
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
* Adding the `notes` add-on for storybook
* `Carousel` component, which is the most basic wrapper for `Flickity` I could cook up. This components needs to be wrapped by another component to render properly so I am not adding this to the default exports. Once we create carousels for DocumentCards, etc we will add those as exports
* include `carousel` css as an export - I did not include this in the global styles in the case where jarvis or espresso doesn't want to include this css (might already have it)