### PR TITLE
move react scripts to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atk/mise-ui",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "algoliasearch": "^4.0.3",
@@ -10,7 +10,6 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-instantsearch-dom": "^6.3.0",
-    "react-scripts": "3.3.1",
     "styled-components": "5.0.1",
     "styled-components-breakpoint": "2.1.1",
     "styled-normalize": "^8.0.7"
@@ -82,6 +81,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "jest": "24.9.0",
     "jest-styled-components": "^7.0.2",
+    "react-scripts": "3.3.1",
     "react-test-renderer": "^16.12.0",
     "watch": "^1.0.2"
   },


### PR DESCRIPTION
heroku complains about the 'slug' size on jarvis builds. The slug is basically the zip file that heroku gets from our repo's dependencies. `react-scripts` is huge and we don't need it in our main dependencies as far as I can tell. Moving it to `devDependencies` gets rid of the warning on jarvis and speeds up the jarvis builds.