### PR TITLE
remove api logic from podcast episode card component

### DIFF
--- a/src/components/Cards/PodcastEpisodeCard/PodcastEpisodeCard.stories.js
+++ b/src/components/Cards/PodcastEpisodeCard/PodcastEpisodeCard.stories.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
+import fetch from 'cross-fetch';
 
 import PodcastEpisodeCard from './index';
 
@@ -9,17 +10,54 @@ export default {
   decorators: [withKnobs],
 };
 
-export const Default = () => (
-  <PodcastEpisodeCard
-    episode={8}
-    title={text('Title', 'Exodus Bagels: A Small Business and COVID-19')}
-    description={text('Description', 'This is the story of one family, struggling to save their bagel cafe in Boston during the COVID-19 pandemic.')}
-    href="https://www.americastestkitchen.com/proof/exodus-bagels-covid-19"
-    id="ffbb762f-7b06-41a1-bbd1-95bf1a6d1ff6"
-    isPlaying={select('Currently Playing', [true, false], false)}
-    imageAlt={text('Image alt', '')}
-    imageId={text('Image url', "af10331a-ab7d-4193-80e1-5f4776340af8")}
-    siteKey="atk"
-    stickers={[{ type: 'editorial', text: '28:08' }]}
-  />
-);
+export const Default = () => {
+  const episode = {
+    cascaded_cover_image_id: "af10331a-ab7d-4193-80e1-5f4776340af8",
+    cover_image_id: null,
+    episode_number: 8,
+    id: "ffbb762f-7b06-41a1-bbd1-95bf1a6d1ff6",
+    rss_link_url: "https://www.americastestkitchen.com/proof/exodus-bagels-covid-19",
+    summary: "This is the story of one family, struggling to save their bagel cafe in Boston during the COVID-19 pandemic.",
+    title: "Exodus Bagels: A Small Business and COVID-19",
+  }
+
+  const [imageUrl, setImageUrl] = useState('');
+
+  useEffect(() => {
+    async function fetchData() {
+      const response = await fetch(
+        `https://art19.com/images/${episode.cover_image_id || episode.cascaded_cover_image_id}`,
+        {
+          method: 'GET',
+          headers: {
+            'Accept': 'application/vnd.api+json',
+            'Authorization': 'Token token="jQ-ldsLx7USTQ4mjtOEBPIOsEXAno8UTh8l2KomNLQM5B75NUL-P9iFVGd1lF6c9-Lcq1dmUFTmhZTBsb09BmA", credential="14c39803-3e99-47c4-a4d3-d79398e74089"',
+          },
+          mode: 'no-cors',
+        },
+      );
+      const imageData = await response.json().catch((err) => {
+        console.error('REQUEST RESPONSE.JSON PARSING ERROR', url); // eslint-disable-line
+        console.error(err); // eslint-disable-line
+      });
+      const image = imageData.media_assets.filter(image => image.size_height === 640)[0];
+      setImageUrl(image.cdn_url);
+    }
+    fetchData();
+  }, []);
+  
+  return (
+    <PodcastEpisodeCard
+      episode={episode.episode_number}
+      title={text('Title', episode.title)}
+      description={text('Description', episode.summary)}
+      href={text('Detail Page URL', episode.rss_link_url)}
+      id={episode.id}
+      isPlaying={select('Currently Playing', [true, false], false)}
+      imageAlt={text('Image alt', '')}
+      imageUrl={imageUrl}
+      siteKey="atk"
+      stickers={[{ type: 'editorial', text: '28:08' }]}
+    />
+  )
+};

--- a/src/components/Cards/PodcastEpisodeCard/index.js
+++ b/src/components/Cards/PodcastEpisodeCard/index.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import styled from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
-import fetch from 'cross-fetch';
 import { color, font, fontSize, spacing, lineHeight, letterSpacing, mixins } from '../../../styles';
 
 import { VideoPlay } from '../../DesignTokens/Icon';
@@ -95,6 +94,7 @@ const NowPlayingSticker = styled(Sticker)`
   &.now-playing > * {
     background-color: ${color.darkerMint};
     font-size: ${fontSize.xsm};
+    margin-left: 0;
     transform: none;
   }
 `;
@@ -180,30 +180,6 @@ const TextWrapper = styled.div`
 `;
 
 class PodcastEpisodeCard extends Component {
-  componentDidMount() {
-    const { imageId } = this.props;
-    fetch(
-      `https://art19.com/images/${imageId}`,
-      {
-        method: 'GET',
-        headers: {
-          Accept: 'application/vnd.art19.v0+json;q=0.9,application/json;q=0.8',
-          Authorization: 'Token token="jQ-ldsLx7USTQ4mjtOEBPIOsEXAno8UTh8l2KomNLQM5B75NUL-P9iFVGd1lF6c9-Lcq1dmUFTmhZTBsb09BmA", credential="14c39803-3e99-47c4-a4d3-d79398e74089"',
-        },
-        mode: 'cors',
-      },
-    )
-      .then(response => response.json())
-      .then((data) => {
-        const image = data.media_assets.filter(image => image.size_height === 640);
-        this.imageUrl = image.cdn_url;
-      },
-      )
-      .catch((error) => {
-        console.log(error);
-      });
-  }
-
   setEpisode = (episode) => {
     const { setEpisode } = this.props;
     setEpisode(episode); // call method
@@ -217,7 +193,7 @@ class PodcastEpisodeCard extends Component {
       href,
       id,
       imageAlt,
-      imageId,
+      imageUrl,
       siteKey,
       stickers,
       isPlaying,
@@ -232,7 +208,7 @@ class PodcastEpisodeCard extends Component {
             <Image
               aria-hidden="true"
               imageAlt={imageAlt}
-              imageUrl={this.imageUrl || 'https://res.cloudinary.com/hksqkdlah/image/upload/c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,h_460,q_auto:low,w_460/v1/Proof%20Season%204/04-Pandemic_Exodus_Bagels2'}
+              imageUrl={imageUrl}
             />
             <StyledBadge
               type={siteKey}
@@ -256,7 +232,7 @@ class PodcastEpisodeCard extends Component {
                 href,
                 id,
                 imageAlt,
-                imageId,
+                imageUrl,
                 siteKey,
                 stickers,
               })}
@@ -266,7 +242,7 @@ class PodcastEpisodeCard extends Component {
               <h3>{title}</h3>
             </button>
             <p>{description} </p>
-            <span>•••</span><a href={href}>More From This Episode</a>
+            {href && <> <span>•••</span><a href={href}>More From This Episode</a></>}
           </TextWrapper>
         </div>
         <p>{description} </p>
@@ -288,7 +264,7 @@ PodcastEpisodeCard.propTypes = {
   id: PropTypes.string.isRequired,
   isPlaying: PropTypes.bool,
   imageAlt: PropTypes.string,
-  imageId: PropTypes.string,
+  imageUrl: PropTypes.string,
   siteKey: PropTypes.string.isRequired,
   stickers: PropTypes.array,
   setEpisode: PropTypes.func,
@@ -296,7 +272,7 @@ PodcastEpisodeCard.propTypes = {
 
 PodcastEpisodeCard.defaultProps = {
   imageAlt: ' ',
-  imageId: '',
+  imageUrl: '',
   isPlaying: false,
   stickers: [],
   setEpisode: null,


### PR DESCRIPTION
I thought it would be better to move this logic outside of the component (and have it in espresso instead) 