### PR TITLE
add height and width value to carousel dots

### DIFF
--- a/src/components/Carousels/CardCarousel/index.js
+++ b/src/components/Carousels/CardCarousel/index.js
@@ -16,6 +16,11 @@ const CardCarouselTheme = {
     max-width: 100%;
     position: relative;
 
+    .flickity-page-dots {
+      height: 1.2rem;
+      width: auto;
+    }
+
     .linear-gradient {
       display: none;
     }


### PR DESCRIPTION
dot container was full width & height of carousel. this blocked interaction with cards and CTAs