### PR TITLE
episode detail page work

### DIFF
--- a/src/components/Buttons/ActionButtons/FavoriteActionButton/__tests__/FavoriteActionButton.spec.js
+++ b/src/components/Buttons/ActionButtons/FavoriteActionButton/__tests__/FavoriteActionButton.spec.js
@@ -34,6 +34,6 @@ describe('FavoriteActionButton component', () => {
 
   it('render button text', () => {
     renderComponent(saveToFavoritesButton);
-    expect(screen.getByText('Saved'));
+    expect(screen.getByTestId('saved'));
   });
 });

--- a/src/components/Buttons/ActionButtons/FavoriteActionButton/index.js
+++ b/src/components/Buttons/ActionButtons/FavoriteActionButton/index.js
@@ -24,6 +24,11 @@ const StyledButton = styled(Button)`
   justify-content: center;
   letter-spacing: ${letterSpacing.md};
 
+  em {
+    display: none;
+    font-style: normal;
+  }
+
   &.favorite-action,
   &.favorite-manage {
     display: flex;
@@ -39,6 +44,21 @@ const StyledButton = styled(Button)`
   &.favorite-manage {
     background: ${color.mint};
     flex-basis: 6rem;
+  }
+
+  &.favorited {
+    ${StyledFavoriteRibbon} {
+      fill: white;
+
+      [class*="vertical-line"],
+      [class*="horizontal-line"] {
+        stroke: white;
+      }
+    }
+
+    em {
+      display: inline;
+    }
   }
 
   ${StyledFavoriteRibbon} {
@@ -64,12 +84,16 @@ const StyledFolder = styled(Folder)`
 
 function FavoriteActionButton({
   className,
+  favoritableId,
   isFavorited,
   onClick,
+  title,
 }) {
   return (
     <ButtonWrapper>
       <StyledButton
+        data-favoritable-id={favoritableId}
+        data-document-title={title}
         className="favorite-action"
         isFavorited={isFavorited}
       >
@@ -80,7 +104,7 @@ function FavoriteActionButton({
           fill={color.white}
           onClick={onClick}
         />
-        { isFavorited ? 'Saved' : 'Save' }
+        <span>Save<em data-testid="saved">d</em></span>
       </StyledButton>
       { isFavorited && (
         <StyledButton
@@ -103,14 +127,18 @@ function FavoriteActionButton({
 
 FavoriteActionButton.propTypes = {
   className: PropTypes.string,
+  favoritableId: PropTypes.string,
   isFavorited: PropTypes.bool,
   onClick: PropTypes.func,
+  title: PropTypes.string,
 };
 
 FavoriteActionButton.defaultProps = {
   className: '',
+  favoritableId: null,
   isFavorited: false,
   onClick: () => {},
+  title: null,
 };
 
 export default FavoriteActionButton;

--- a/src/components/Buttons/Button/index.js
+++ b/src/components/Buttons/Button/index.js
@@ -37,12 +37,14 @@ function Button({
   children,
   onClick,
   type,
+  ...restProps
 }) {
   return (
     <StyledButton
       className={className}
       onClick={onClick}
       type={type}
+      {...restProps}
     >
       {children}
     </StyledButton>

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -148,13 +148,12 @@ export const StyledBadge = styled(Badge)`
 
 function StandardCard({
   className,
-  commentCount,
   contentType,
   contentTypeFormatted,
   ctaText,
   ctaUrl,
   displayCookbook,
-  displayCommentCount,
+  displaySecondaryAttribution,
   displayFavoritesButton,
   displayLockIcon,
   favoriteRibbonColor,
@@ -164,6 +163,7 @@ function StandardCard({
   isFavorited,
   objectId,
   onClick,
+  secondaryAttribution,
   shopPrices,
   siteKey,
   siteKeyFavorites,
@@ -224,11 +224,11 @@ function StandardCard({
         </TitleWrapper>
       </a>
       <StyledAttributions
-        commentCount={commentCount}
-        contentType={contentTypeFormatted || contentType}
         displayCookbook={displayCookbook}
         displayLockIcon={displayLockIcon}
-        displayCommentCount={displayCommentCount}
+        displaySecondaryAttribution={displaySecondaryAttribution}
+        primaryAttribution={contentTypeFormatted || contentType}
+        secondaryAttribution={secondaryAttribution}
         shopPrices={shopPrices}
       />
       {
@@ -249,11 +249,10 @@ StandardCard.propTypes = {
   className: PropTypes.string,
   contentType: PropTypes.string.isRequired,
   contentTypeFormatted: PropTypes.string,
-  commentCount: PropTypes.number,
   ctaText: PropTypes.string,
   ctaUrl: PropTypes.string,
   displayCookbook: PropTypes.bool,
-  displayCommentCount: PropTypes.bool,
+  displaySecondaryAttribution: PropTypes.bool,
   displayLockIcon: PropTypes.bool,
   favoriteRibbonColor: PropTypes.string,
   href: PropTypes.string.isRequired,
@@ -262,6 +261,10 @@ StandardCard.propTypes = {
   isFavorited: PropTypes.bool,
   objectId: PropTypes.string.isRequired,
   onClick: PropTypes.func,
+  secondaryAttribution: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   shopPrices: PropTypes.object,
   siteKey: PropTypes.oneOf(['atk', 'cco', 'cio', 'kids', 'school', 'shop']).isRequired,
   siteKeyFavorites: PropTypes.oneOf(['atk', 'cco', 'cio']),
@@ -272,12 +275,11 @@ StandardCard.propTypes = {
 
 StandardCard.defaultProps = {
   className: null,
-  commentCount: null,
   contentTypeFormatted: null,
   ctaText: '',
   ctaUrl: '',
   displayCookbook: false,
-  displayCommentCount: false,
+  displaySecondaryAttribution: false,
   displayFavoritesButton: false,
   displayLockIcon: false,
   favoriteRibbonColor: color.eclipse,
@@ -285,6 +287,7 @@ StandardCard.defaultProps = {
   imageUrl: '',
   isFavorited: false,
   onClick: null,
+  secondaryAttribution: null,
   shopPrices: null,
   siteKeyFavorites: null,
   stickers: [],

--- a/src/components/Cards/__tests__/StandardCard.spec.js
+++ b/src/components/Cards/__tests__/StandardCard.spec.js
@@ -17,13 +17,13 @@ import breakpoints from '../../../styles/breakpoints';
 
 const baseRecipe = {
   className: null,
-  commentCount: 1,
+  secondaryAttribution: 1,
   contentType: 'recipe',
   contentTypeFormatted: 'Recipe',
   ctaText: null,
   ctaUrl: null,
   displayCookbook: false,
-  displayCommentCount: true,
+  displaySecondaryAttribution: true,
   displayFavoritesButton: false,
   displayLockIcon: true,
   stickers: [{ text: 'new', type: 'priority' }],
@@ -41,13 +41,13 @@ const baseRecipe = {
 
 const baseTasteTest = {
   className: null,
-  commentCount: 1,
+  secondaryAttribution: 1,
   contentType: 'taste_test',
   contentTypeFormatted: 'Taste Test',
   ctaText: 'Buy The Winner',
   ctaUrl: 'http://www.amazon.com/dp/B00N9TX628/?tag=atksearchresult-20',
   displayCookbook: false,
-  displayCommentCount: true,
+  displaySecondaryAttribution: true,
   displayFavoritesButton: false,
   displayLockIcon: true,
   stickers: [{ text: '6 tested', type: 'editorial' }],
@@ -116,7 +116,9 @@ describe('StandardCard component', () => {
 
   it('Renders with a comment count', () => {
     const testInstance = componentSetup(baseRecipe);
-    expect(testInstance.findByType(Attributions).props.commentCount).toBe(baseRecipe.commentCount);
+    expect(
+      testInstance.findByType(Attributions).props.secondaryAttribution,
+    ).toBe(baseRecipe.secondaryAttribution);
   });
 
   it('Renders fallback content type attribution', () => {
@@ -124,7 +126,9 @@ describe('StandardCard component', () => {
       ...baseRecipe,
       contentTypeFormatted: null,
     });
-    expect(testInstance.findByType(Attributions).props.contentType).toBe(baseRecipe.contentType);
+    expect(
+      testInstance.findByType(Attributions).props.primaryAttribution,
+    ).toBe(baseRecipe.contentType);
   });
 
   it('Renders without a FavoriteButton', () => {

--- a/src/components/Cards/shared/Attributions/index.js
+++ b/src/components/Cards/shared/Attributions/index.js
@@ -33,22 +33,22 @@ const StyledCookbook = styled(Cookbook)`
 
 const Attributions = ({
   className,
-  contentType,
   displayCookbook,
   displayLockIcon,
-  commentCount,
-  displayCommentCount,
+  displaySecondaryAttribution,
+  primaryAttribution,
+  secondaryAttribution,
   shopPrices,
 }) => (
   <StyledAttributions>
     <div className="attributions__content-type-wrapper">
       { displayLockIcon ? <StyledLock className="lock-icon" fill={`${color.nobel}`} /> : null }
-      { contentType === 'Cookbook Collection' || displayCookbook ? (
+      { primaryAttribution === 'Cookbook Collection' || displayCookbook ? (
         <StyledCookbook
           className={className}
         />
       ) : null }
-      {!shopPrices ? <span>{contentType}</span> : null}
+      {!shopPrices ? <span>{primaryAttribution}</span> : null}
       {
         shopPrices ? (
           <span>
@@ -68,10 +68,10 @@ const Attributions = ({
         ) : null
       }
     </div>
-    { displayCommentCount && commentCount > 0 ? (
+    { displaySecondaryAttribution && secondaryAttribution ? (
       <>
         <span className="attributions__bullet">•</span>
-        <span>{commentCount} {commentCount === 1 ? 'Comment' : 'Comments' }</span>
+        <span>{secondaryAttribution}</span>
       </>
     ) : null }
   </StyledAttributions>
@@ -79,20 +79,20 @@ const Attributions = ({
 
 Attributions.propTypes = {
   className: PropTypes.string,
-  commentCount: PropTypes.number,
-  contentType: PropTypes.string.isRequired,
   displayLockIcon: PropTypes.bool,
-  displayCommentCount: PropTypes.bool,
+  displaySecondaryAttribution: PropTypes.bool,
   displayCookbook: PropTypes.bool,
+  primaryAttribution: PropTypes.string.isRequired,
+  secondaryAttribution: PropTypes.number,
   shopPrices: PropTypes.object,
 };
 
 Attributions.defaultProps = {
   className: '',
-  commentCount: null,
-  displayCommentCount: false,
+  displaySecondaryAttribution: false,
   displayCookbook: false,
   displayLockIcon: false,
+  secondaryAttribution: null,
   shopPrices: null,
 };
 

--- a/src/components/Carousels/CardCarousel/index.js
+++ b/src/components/Carousels/CardCarousel/index.js
@@ -73,7 +73,7 @@ const CardCarouselTheme = {
       overflow: visible;
     }
 
-    .linear-gradient {
+    .flickity-enabled ~ .linear-gradient {
       height: 100%;
       position: absolute;
       right: 0;
@@ -117,7 +117,6 @@ const CardCarouselTheme = {
 
       &.card-carousel--hero {
         .linear-gradient {
-
           &:last-child {
             right: -3rem;
           }

--- a/src/components/Carousels/Carousel/index.js
+++ b/src/components/Carousels/Carousel/index.js
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import { color, spacing, withThemes } from '../../../styles';
@@ -56,6 +56,7 @@ const CarouselTheme = {
     }
 
     &:not(.flickity-enabled) {
+      display: flex;
       overflow: hidden;
 
       .slideshow & {
@@ -202,6 +203,7 @@ const defaultOptions = {
 const Carousel = ({ className, dotPosition, items, options, renderItem }) => {
   const elRef = useRef(null);
   const flktyRef = useRef();
+  const [enabled, setEnabled] = useState(false);
   const opts = { ...defaultOptions, ...options };
   const { slideshow } = opts;
 
@@ -209,8 +211,10 @@ const Carousel = ({ className, dotPosition, items, options, renderItem }) => {
     if (flktyRef.current) flktyRef.current.destroy();
     if (items.length > 1 && elRef?.current) {
       const flkty = getFlickityInstance(elRef.current, opts);
-      if (flkty.slides.length === 1) flkty.destroy();
+      const isEnabled = flkty.slides.length > 1;
+      if (isEnabled === false) flkty.destroy();
       else flktyRef.current = flkty;
+      setEnabled(isEnabled);
     }
     return () => {
       try { if (flktyRef.current) flktyRef.current.destroy(); } // eslint-disable-line
@@ -220,7 +224,11 @@ const Carousel = ({ className, dotPosition, items, options, renderItem }) => {
 
   return (
     <CarouselWrapper
-      className={`carousel-wrapper${slideshow ? ' slideshow' : ''}`}
+      className={[
+        'carousel-wrapper',
+        slideshow ? ' slideshow' : '',
+        enabled ? 'flickity-enabled' : '',
+      ].join(' ')}
     >
       <CarouselEl
         className={className}

--- a/src/components/Carousels/DocumentListCarousel/index.js
+++ b/src/components/Carousels/DocumentListCarousel/index.js
@@ -141,7 +141,7 @@ DocumentListCarousel.propTypes = {
   /** Larger title displayed above carousel */
   title: PropTypes.string.isRequired,
   /** Sets the carousel-item styles for a particular card style */
-  type: PropTypes.oneOf(['standard', 'feature', 'person']).isRequired,
+  type: PropTypes.oneOf(['standard', 'feature', 'person', 'tall']).isRequired,
 };
 
 DocumentListCarousel.defaultProps = {

--- a/src/components/DesignTokens/LinearGradient/index.js
+++ b/src/components/DesignTokens/LinearGradient/index.js
@@ -8,6 +8,14 @@ const LinearGradientTheme = {
   default: css`
     background-blend-mode: multiply;
     background-image: ${({ angle, startColor, endColor, stop }) => `linear-gradient(${angle}deg, ${color[startColor]}, ${color[endColor]} ${stop})`};
+
+    .jet-gradient & {
+      background-image: ${({ angle, stop }) => `linear-gradient(${angle}deg, ${color.transparentBlack}, ${color.jet} ${stop})`};
+    }
+
+    .asphalt-gradient & {
+      background-image: ${({ angle, stop }) => `linear-gradient(${angle}deg, ${color.transparentBlack}, ${color.asphalt} ${stop})`};
+    }
   `,
   dark: css`
     background-image: ${({ angle, stop }) => `linear-gradient(${angle}deg, transparent, ${color.gunmetal} ${stop})`};

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -30,6 +30,7 @@ const color = {
   email: '#3d3d3d',
   emailHover: '#94856b',
   jade: '#00A26D',
+  jet: '#080808',
   facebook: '#527aa1',
   facebookHover: '#43637a',
   pinterest: '#cf5553',


### PR DESCRIPTION
* Favorite Action component needs to work based on `.favorited` classname, as that's what the widgets use to mark something as favorited
* Swap out comment-count and doc type specific props in StandardCard for something more generic. Need to check jarvis on this one.
* Carousel updates - make it easier to style the gradient - passing props through the components is awkward at best in this scenario. Using a classname on a parent container is a good tradeoff.
* Handle scenario where there's not enough carousel items to make 2 pages a little better