### PR TITLE
highlighted card

### DIFF
--- a/src/components/Cards/CardWrapper/CardWrapper.stories.js
+++ b/src/components/Cards/CardWrapper/CardWrapper.stories.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import styled, { css, ThemeProvider } from 'styled-components';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, text } from '@storybook/addon-knobs';
+
+import CardWrapper from './index';
+import { breakpoints, color, withThemes } from '../../../styles'
+
+
+export default {
+  title: 'Components|Cards/CardWrapper',
+  component: CardWrapper,
+  decorators: [withKnobs],
+};
+
+const StoryWrapperTheme = {
+  default: css`
+    padding: 2rem 0 2rem 1.6rem;
+  `,
+  dark: css`
+    background-color: ${color.gunmetal};
+  `,
+};
+
+const StoryWrapper = styled.div`
+  ${withThemes(StoryWrapperTheme)}
+`;
+
+const wideCard = {
+  attributions: 'Episode • America’s Test Kitchen',
+  contentType: 'episode',
+  displayFavoritesButton: true,
+  href: 'https://www.americastestkitchen.com/episode/658-savory-and-sweet-italian',
+  imageAlt: 'Hosts Bridget and Dan on set at ATK',
+  imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/v1592840035/mise-play/feature-card-wide.jpg',
+  isWide: true,
+  siteKey: 'atk',
+  siteKeyFavorites: 'atk',
+  stickers: [
+    { type: 'priority', text: 'New' },
+    { type: 'editorial', text: '23:23'},
+  ],
+  objectId: 'episode_1234',
+  title: 'Savory and Sweet Italian'
+};
+
+const standardCard = { ...wideCard };
+delete standardCard.isWide;
+
+export const Wide = () => (
+  <ThemeProvider theme={{
+    breakpoints,
+    mode: 'dark'
+  }}>
+    <StoryWrapper className="story-wrapper">
+      <CardWrapper
+        ctaText={text('Cta Text', 'Explore Recipes')}
+        ctaUrl="https://www.americastestkitchen.com/episodes/1234"
+        item={wideCard}
+        title={text('Title', 'Start Cooking')}
+        type="feature"
+      />
+    </StoryWrapper>
+  </ThemeProvider>
+);
+
+export const Standard = () => (
+  <ThemeProvider theme={{
+    breakpoints,
+    mode: 'dark'
+  }}>
+    <StoryWrapper className="story-wrapper">
+      <CardWrapper
+        ctaText={text('Cta Text', 'Explore Recipes')}
+        ctaUrl="https://www.americastestkitchen.com/episodes/1234"
+        item={standardCard}
+        title={text('Title', 'Start Cooking')}
+        type="standard"
+      />
+    </StoryWrapper>
+  </ThemeProvider>
+);
+
+export const Tall = () => (
+  <ThemeProvider theme={{
+    breakpoints,
+    mode: 'dark'
+  }}>
+    <StoryWrapper className="story-wrapper">
+      <CardWrapper
+        ctaText={text('Cta Text', 'Explore Recipes')}
+        ctaUrl="https://www.americastestkitchen.com/episodes/1234"
+        item={standardCard}
+        title={text('Title', 'Start Cooking')}
+        type="talll"
+      />
+    </StoryWrapper>
+  </ThemeProvider>
+);

--- a/src/components/Cards/CardWrapper/__tests__/CardWrapper.spec.js
+++ b/src/components/Cards/CardWrapper/__tests__/CardWrapper.spec.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import 'jest-styled-components';
+
+import CardWrapper from '../index';
+import breakpoints from '../../../../styles/breakpoints';
+
+const wideCard = {
+  attributions: 'Episode • America’s Test Kitchen',
+  contentType: 'episode',
+  displayFavoritesButton: true,
+  href: 'https://www.americastestkitchen.com/episode/658-savory-and-sweet-italian',
+  imageAlt: 'Hosts Bridget and Dan on set at ATK',
+  imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/v1592840035/mise-play/feature-card-wide.jpg',
+  isWide: true,
+  siteKey: 'atk',
+  siteKeyFavorites: 'atk',
+  stickers: [
+    { type: 'priority', text: 'New' },
+    { type: 'editorial', text: '23:23' },
+  ],
+  objectId: 'episode_1234',
+  title: 'Savory and Sweet Italian',
+};
+
+describe('CardWrapper component should', () => {
+  const renderComponent = () => (
+    render(
+      <ThemeProvider theme={{ breakpoints }}>
+        <CardWrapper
+          ctaText="Explore Recipes"
+          ctaUrl="https://www.americastestkitchen.com/episodes/1234"
+          item={wideCard}
+          title="Start Cooking"
+          type="feature"
+        />
+      </ThemeProvider>,
+    )
+  );
+
+  it('render a title', () => {
+    renderComponent();
+    expect(screen.getByText('Start Cooking'));
+  });
+
+  it('render a cta', () => {
+    renderComponent();
+    expect(screen.getByText('Explore Recipes >'));
+  });
+
+  it('render a card', () => {
+    renderComponent();
+    expect(screen.getByTestId('feature-card'));
+  });
+});

--- a/src/components/Cards/CardWrapper/index.js
+++ b/src/components/Cards/CardWrapper/index.js
@@ -1,0 +1,137 @@
+import breakpoint from 'styled-components-breakpoint';
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+
+import FeatureCard from '../FeatureCard';
+import StandardCard from '../StandardCard';
+import TallCard from '../TallCard';
+import {
+  color,
+  font,
+  fontSize,
+  letterSpacing,
+  lineHeight,
+  spacing,
+  withThemes,
+} from '../../../styles';
+
+const CardWrapperWrapperTheme = {
+  default: css`
+  `,
+};
+
+const CardWrapperWrapper = styled.div.attrs({
+  className: 'card-wrapper',
+})`${withThemes(CardWrapperWrapperTheme)}`;
+
+
+const CardWrapperInfoWrapperTheme = {
+  default: css`
+    ${breakpoint('lg')`
+      align-items: center;
+      display: flex;
+      margin-bottom: ${spacing.xsm};
+    `}
+  `,
+};
+
+const CardWrapperInfoWrapper = styled.div.attrs({
+  className: 'card-wrapper__info',
+})`${withThemes(CardWrapperInfoWrapperTheme)}`;
+
+const CardWrapperTitleTheme = {
+  default: css`
+    font: ${fontSize.xl}/1 ${font.pnb};
+    margin-bottom: ${spacing.xsm};
+
+    ${breakpoint('lg')`
+      font-size: ${fontSize.xxl};
+      margin-bottom: 0;
+      margin-right: ${spacing.sm};
+    `}
+  `,
+  dark: css`
+    color: ${color.white};
+  `,
+};
+
+const CardWrapperTitle = styled.h3.attrs({
+  className: 'card-wrapper__title',
+})`${withThemes(CardWrapperTitleTheme)}`;
+
+
+const CardWrapperCtaTheme = {
+  default: css`
+    display: block;
+    font: ${fontSize.sm}/${lineHeight.sm} ${font.pnr};
+    letter-spacing: ${letterSpacing.xlg};
+    margin-bottom: ${spacing.xsm};
+    text-transform: uppercase;
+
+    &:hover {
+      color: ${color.mint};
+    }
+
+    ${breakpoint('lg')`
+      font-size: ${fontSize.md};
+      margin-bottom: 0;
+    `}
+  `,
+  dark: css`
+    color: ${color.white};
+  `,
+};
+
+const CardWrapperCta = styled.a.attrs({
+  className: 'card-wrapper__cta',
+})`${withThemes(CardWrapperCtaTheme)}`;
+
+const typeMap = {
+  feature: FeatureCard,
+  standard: StandardCard,
+  tall: TallCard,
+};
+
+const CardWrapper = ({
+  ctaText,
+  ctaUrl,
+  item,
+  title,
+  type,
+}) => {
+  const El = typeMap[type] || FeatureCard;
+
+  return (
+    <CardWrapperWrapper>
+      <CardWrapperInfoWrapper>
+        <CardWrapperTitle>
+          {title}
+        </CardWrapperTitle>
+        {ctaText && ctaUrl && (
+          <CardWrapperCta href={ctaUrl}>
+            {`${ctaText} >`}
+          </CardWrapperCta>
+        )}
+      </CardWrapperInfoWrapper>
+      <El
+        {...item}
+      />
+    </CardWrapperWrapper>
+  );
+};
+
+CardWrapper.propTypes = {
+  ctaText: PropTypes.string,
+  ctaUrl: PropTypes.string,
+  item: PropTypes.object.isRequired,
+  title: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(['standard', 'feature', 'tall']).isRequired,
+};
+
+CardWrapper.defaultProps = {
+  ctaText: null,
+  ctaUrl: null,
+};
+
+export default CardWrapper;

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import Button from './components/Buttons/Button';
 import carousel from './styles/carousel';
 import Carousel from './components/Carousels/Carousel';
 import CardCarousel from './components/Carousels/CardCarousel';
+import CardWrapper from './components/Cards/CardWrapper';
 import ClearRefinements from './components/Algolia/shared/ClearRefinements';
 import CurrentRefinements from './components/Algolia/shared/CurrentRefinements';
 import DocumentListCarousel from './components/Carousels/DocumentListCarousel';
@@ -58,9 +59,10 @@ export {
   Badge,
   breakpoints,
   Button,
+  CardCarousel,
+  CardWrapper,
   carousel,
   Carousel,
-  CardCarousel,
   CircledText,
   color,
   ClearRefinements,


### PR DESCRIPTION
Highlight card wraps Feature/Tall/Standard cards with a title and cta. This is similar to the document list carousel, but only ever designed for one card. This is featured on the video detail page, where the related recipe/episode/magazine are displayed.