### PR TITLE
allow full width if no sibling for feature card content

### DIFF
--- a/src/components/Cards/FeatureCard/index.js
+++ b/src/components/Cards/FeatureCard/index.js
@@ -41,7 +41,7 @@ const StyledFeatureCard = styled.article`
     color: ${color.white};
   }
 
-  .feature-card__subcomponents-content {
+  .feature-card__subcomponents-content:not(:only-child) {
     flex: 1 0 calc(100% -  6.2rem);
     max-width: calc(100% -  6.2rem);
   }


### PR DESCRIPTION
subcomponents content can be an only child if the optional person headshots are not provided. In that case, don't restrict the width of the div