### PR TITLE
allow HTML in hero description since it is a WYSIWYG field in the admin

### DIFF
--- a/src/components/Cards/HeroCard/index.js
+++ b/src/components/Cards/HeroCard/index.js
@@ -74,7 +74,7 @@ const HeroCardTitle = styled.div`
   margin-bottom: ${spacing.xxsm};
 `;
 
-const HeroCardDescription = styled.p`
+const HeroCardDescription = styled.div`
   color: ${color.white};
   margin-bottom: ${spacing.xsm};
 
@@ -173,9 +173,8 @@ const HeroCard = ({
         }
         <HeroCardDescription
           cardType={personHeadShot && sticker ? 'learn' : 'watch'}
-        >
-          {description}
-        </HeroCardDescription>
+          dangerouslySetInnerHTML={{ __html: description }}
+        />
         <HeroCardCta
           href={ctaUrl}
           onClick={onClick}


### PR DESCRIPTION
This will typically come through as plain text wrapped in a `p`. Don't want a `p` within a `p` so let's make it a `div`