### PR TITLE
we do not want squished heads - set flex-shrink 0 so image wrapper do…

### DIFF
--- a/src/components/Cards/shared/PersonHeadShot/index.js
+++ b/src/components/Cards/shared/PersonHeadShot/index.js
@@ -21,6 +21,7 @@ const PersonHeadShotWrapper = styled.div`
       width: ${lg || md || sm}rem;
     `}
   `}
+  flex-shrink: 0;
   overflow: hidden;
 `;
 


### PR DESCRIPTION
without flex-shrink: 0, the image div will shrink when the card runs out of room vertically b/c this is flex-direction: column