### PR TITLE
hero card carousel gradient adjustments

### DIFF
--- a/src/components/Cards/shared/Attributions/index.js
+++ b/src/components/Cards/shared/Attributions/index.js
@@ -83,7 +83,10 @@ Attributions.propTypes = {
   displaySecondaryAttribution: PropTypes.bool,
   displayCookbook: PropTypes.bool,
   primaryAttribution: PropTypes.string.isRequired,
-  secondaryAttribution: PropTypes.number,
+  secondaryAttribution: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   shopPrices: PropTypes.object,
 };
 

--- a/src/components/Carousels/CardCarousel/index.js
+++ b/src/components/Carousels/CardCarousel/index.js
@@ -95,11 +95,11 @@ const CardCarouselTheme = {
       &.card-carousel--hero {
         .linear-gradient {
 
-          &:first-child {
+          &.left {
             left: 0;
           }
 
-          &:last-child {
+          &.right {
             right: 0;
           }
         }
@@ -168,9 +168,6 @@ const CardCarousel = ({
       data-testid={`card-carousel--${type}`}
       type={type}
     >
-      <LinearGradient
-        angle="-90"
-      />
       <Carousel
         className={className}
         dotPosition={dotPosition}
@@ -179,6 +176,11 @@ const CardCarousel = ({
         options={options}
       />
       <LinearGradient
+        className="left"
+        angle="-90"
+      />
+      <LinearGradient
+        className="right"
         angle="90"
       />
     </CardCarouselWrapper>


### PR DESCRIPTION
Move first gradient to after the `Carousel` so the `~` selector actually works. Also, adding `left` and `right` classnames to the gradients for easier styling.