### PR TITLE
episode detail page fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-loadable": "^5.5.0",
     "react-loadable-visibility": "^3.0.2",
     "react-scripts": "3.3.1",
-    "styled-components": "5.0.1",
+    "styled-components": "5.2.0",
     "styled-components-breakpoint": "2.1.1",
     "styled-normalize": "^8.0.7",
     "verge": "^1.10.2"
@@ -79,7 +79,7 @@
     "auto": "^9.19.4",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^24.9.0",
-    "babel-plugin-styled-components": "^1.10.7",
+    "babel-plugin-styled-components": "^1.11.1",
     "cross-env": "^7.0.2",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.1.0",
@@ -90,9 +90,12 @@
     "eslint-plugin-react-hooks": "^3.0.0",
     "eslint-plugin-standard": "^4.0.1",
     "jest": "26.4.0",
-    "jest-styled-components": "^7.0.2",
+    "jest-styled-components": "^7.0.3",
     "react-test-renderer": "^16.12.0",
     "watch": "^1.0.2"
+  },
+  "resolutions": {
+    "styled-components": "^5"
   },
   "description": "Design system and component library for America's Test Kitchen",
   "main": "./dist/index.js",

--- a/src/components/Ads/HeroAd/__tests__/HeroAd.spec.js
+++ b/src/components/Ads/HeroAd/__tests__/HeroAd.spec.js
@@ -52,11 +52,11 @@ describe('HeroAd', () => {
 
   it('renders correct background color', () => {
     renderComponent();
-    expect(screen.getByTestId('hero-ad__inner')).toHaveStyle(`background-color: ${color.darkSlate};`);
+    expect(screen.getByTestId('hero-ad__inner')).toHaveStyleRule(`background-color: ${color.darkSlate};`);
   });
 
   it('renders correct button color', () => {
     renderComponent();
-    expect(screen.getByTestId('hero-ad__cta')).toHaveStyle(`background-color: ${color.summerSky};`);
+    expect(screen.getByTestId('hero-ad__cta')).toHaveStyleRule(`background-color: ${color.summerSky};`);
   });
 });

--- a/src/components/Ads/HeroAd/index.js
+++ b/src/components/Ads/HeroAd/index.js
@@ -171,7 +171,7 @@ const HeroAdCtaTheme = {
     background-color: ${({ backgroundColor }) => `${color[backgroundColor || 'eclipse']}`};
     display: block;
     font: ${fontSize.md}/4rem ${font.pnb};
-    letter-spacing: ${letterSpacing.xlg};
+    letter-spacing: ${letterSpacing.cta};
     height: 4rem;
     text-align: center;
     text-transform: uppercase;

--- a/src/components/Ads/PairedProductAd/index.js
+++ b/src/components/Ads/PairedProductAd/index.js
@@ -204,7 +204,7 @@ const PairedProductCtaTheme = {
     display: block;
     flex: 1 0 100%;
     font: ${fontSize.lg}/4rem ${font.pnb};
-    letter-spacing: ${letterSpacing.xlg};
+    letter-spacing: ${letterSpacing.cta};
     height: 4rem;
     margin-top: ${spacing.xsm};
     text-align: center;

--- a/src/components/Ads/ShowcaseAds/FreeTrialAd/index.js
+++ b/src/components/Ads/ShowcaseAds/FreeTrialAd/index.js
@@ -116,7 +116,7 @@ const FreeTrialCtaTheme = {
     color: ${color.white};
     display: block;
     font: ${fontSize.lg}/4rem ${font.pnb};
-    letter-spacing: ${letterSpacing.xlg};
+    letter-spacing: ${letterSpacing.cta};
     height: 4rem;
     text-align: center;
     text-transform: uppercase;

--- a/src/components/Ads/ShowcaseAds/MembershipShowcaseAd/index.js
+++ b/src/components/Ads/ShowcaseAds/MembershipShowcaseAd/index.js
@@ -84,7 +84,7 @@ const MembershipCtaTheme = {
     display: block;
     font: ${fontSize.lg}/4rem ${font.pnb};
     height: 4rem;
-    letter-spacing: ${letterSpacing.xlg};
+    letter-spacing: ${letterSpacing.cta};
     margin-bottom: ${spacing.sm};
     text-align: center;
     text-transform: uppercase;

--- a/src/components/Ads/ShowcaseAds/SchoolAd/index.js
+++ b/src/components/Ads/ShowcaseAds/SchoolAd/index.js
@@ -148,7 +148,7 @@ const SchoolCtaTheme = {
     display: block;
     flex: 1 0 100%;
     font: ${fontSize.lg}/4rem ${font.pnb};
-    letter-spacing: ${letterSpacing.xlg};
+    letter-spacing: ${letterSpacing.cta};
     height: 4rem;
     margin-top: ${spacing.xsm};
     text-align: center;

--- a/src/components/Ads/ShowcaseAds/SingleProductShowcaseAd/index.js
+++ b/src/components/Ads/ShowcaseAds/SingleProductShowcaseAd/index.js
@@ -101,7 +101,7 @@ const ProductTitleTheme = {
     margin-bottom: ${spacing.sm};
   `,
   dark: css`
-    color: ${color.white}
+    color: ${color.whiteSmoke}
   `,
 };
 const ProductTitle = styled.h3.attrs({
@@ -135,7 +135,7 @@ const ProductCtaTheme = {
     display: block;
     flex: 1 0 100%;
     font: ${fontSize.lg}/4rem ${font.pnb};
-    letter-spacing: ${letterSpacing.xlg};
+    letter-spacing: ${letterSpacing.cta};
     height: 4rem;
     margin-top: ${spacing.xsm};
     text-align: center;

--- a/src/components/Ads/SingleMembershipAd/index.js
+++ b/src/components/Ads/SingleMembershipAd/index.js
@@ -148,7 +148,7 @@ const SingleMembershipCtaTheme = {
     display: block;
     font: ${fontSize.lg}/4rem ${font.pnb};
     height: 4rem;
-    letter-spacing: ${letterSpacing.xlg};
+    letter-spacing: ${letterSpacing.cta};
     margin-bottom: ${spacing.sm};
     text-align: center;
     text-transform: uppercase;

--- a/src/components/Ads/SingleProductAd/index.js
+++ b/src/components/Ads/SingleProductAd/index.js
@@ -127,7 +127,7 @@ const SingleProductCtaTheme = {
     color: ${color.white};
     display: block;
     font: ${fontSize.lg}/4rem ${font.pnb};
-    letter-spacing: ${letterSpacing.xlg};
+    letter-spacing: ${letterSpacing.cta};
     height: 4rem;
     text-align: center;
     text-transform: uppercase;

--- a/src/components/Algolia/shared/SortBy/__tests__/SortBy.spec.js
+++ b/src/components/Algolia/shared/SortBy/__tests__/SortBy.spec.js
@@ -27,7 +27,7 @@ describe('SortBy component should', () => {
         },
       ],
     });
-    expect(screen.getByTestId('sort-by__radio')).toHaveStyle(`background-color: ${color.mint};`);
+    expect(screen.getByTestId('sort-by__radio')).toHaveStyleRule(`background-color: ${color.mint};`);
   });
 
   it('render empty radio for unrefined value', () => {
@@ -40,6 +40,6 @@ describe('SortBy component should', () => {
         },
       ],
     });
-    expect(screen.getByTestId('sort-by__radio')).toHaveStyle('background-color: transparent;');
+    expect(screen.getByTestId('sort-by__radio')).toHaveStyleRule('background-color: transparent;');
   });
 });

--- a/src/components/Badge/__tests__/__snapshots__/Badge.spec.js.snap
+++ b/src/components/Badge/__tests__/__snapshots__/Badge.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`components renders a cco badge 1`] = `
 <svg
   aria-label="CCO"
-  className="sc-AxjAm fBdxjG badge"
+  className="sc-bdnylx nmOjv badge"
   data-testid="badge"
   role="img"
   viewBox="0 0 25 25"
@@ -71,7 +71,7 @@ exports[`components renders a cco badge 1`] = `
 exports[`components renders a cio badge 1`] = `
 <svg
   aria-label="CIO"
-  className="sc-AxjAm fBdxjG badge"
+  className="sc-bdnylx nmOjv badge"
   data-testid="badge"
   role="img"
   viewBox="0 0 25 25"
@@ -93,7 +93,7 @@ exports[`components renders a cio badge 1`] = `
 exports[`components renders a kids badge 1`] = `
 <svg
   aria-label="KIDS"
-  className="sc-AxjAm fBdxjG badge"
+  className="sc-bdnylx nmOjv badge"
   data-testid="badge"
   role="img"
   viewBox="0 0 25 25"
@@ -153,7 +153,7 @@ exports[`components renders a kids badge 1`] = `
 exports[`components renders an atk badge 1`] = `
 <svg
   aria-label="ATK"
-  className="sc-AxjAm fBdxjG badge"
+  className="sc-bdnylx nmOjv badge"
   data-testid="badge"
   role="img"
   viewBox="0 0 25 25"

--- a/src/components/Cards/CardWrapper/index.js
+++ b/src/components/Cards/CardWrapper/index.js
@@ -65,7 +65,7 @@ const CardWrapperCtaTheme = {
   default: css`
     display: block;
     font: ${fontSize.sm}/${lineHeight.sm} ${font.pnr};
-    letter-spacing: ${letterSpacing.xlg};
+    letter-spacing: ${letterSpacing.cta};
     margin-bottom: ${spacing.xsm};
     text-transform: uppercase;
 

--- a/src/components/Cards/FeatureCard/__tests__/FeatureCard.spec.js
+++ b/src/components/Cards/FeatureCard/__tests__/FeatureCard.spec.js
@@ -67,7 +67,7 @@ describe('FeatureCard component should', () => {
   it('have correct width and height', () => {
     renderComponent();
     const featureCard = screen.getByTestId('feature-card');
-    expect(featureCard).toHaveStyle('width: 27.2rem');
-    expect(featureCard).toHaveStyle('height: 40rem');
+    expect(featureCard).toHaveStyleRule('width: 27.2rem');
+    expect(featureCard).toHaveStyleRule('height: 40rem');
   });
 });

--- a/src/components/Cards/PersonCard/__tests__/PersonCard.spec.js
+++ b/src/components/Cards/PersonCard/__tests__/PersonCard.spec.js
@@ -40,7 +40,7 @@ describe('PersonCard component should', () => {
   it('have correct width and height', () => {
     renderComponent();
     const personCard = screen.getByTestId('person-card');
-    expect(personCard).toHaveStyle('width: 27.2rem');
-    expect(personCard).toHaveStyle('height: 27.2rem');
+    expect(personCard).toHaveStyleRule('width: 27.2rem');
+    expect(personCard).toHaveStyleRule('height: 27.2rem');
   });
 });

--- a/src/components/Cards/PersonCard/index.js
+++ b/src/components/Cards/PersonCard/index.js
@@ -20,7 +20,7 @@ const PersonCardWrapper = styled.div`
   }
 
   a {
-    ${mixins.styledLink(color.turquoise, color.darkerMint)}
+    ${mixins.styledLink(color.turquoise, color.darkerMint)};
   }
 `;
 

--- a/src/components/Cards/TallCard/__test__/TallCard.spec.js
+++ b/src/components/Cards/TallCard/__test__/TallCard.spec.js
@@ -57,7 +57,7 @@ describe('TallCard component should', () => {
   it('have correct width and height', () => {
     renderComponent();
     const tallCard = screen.getByTestId('tall-card');
-    expect(tallCard).toHaveStyle(`width: ${cards.standard.width.lg}`);
-    expect(tallCard).toHaveStyle('height: 60rem');
+    expect(tallCard).toHaveStyleRule(`width: ${cards.standard.width.lg}`);
+    expect(tallCard).toHaveStyleRule('height: 60rem');
   });
 });

--- a/src/components/Cards/__tests__/QueueCard.spec.js
+++ b/src/components/Cards/__tests__/QueueCard.spec.js
@@ -58,7 +58,7 @@ describe('QueueCard component', () => {
   it('has correct width', () => {
     renderComponent(inProgressEpisode);
     const queueCard = screen.getByTestId('queue-card');
-    expect(queueCard).toHaveStyle('width: 27.2rem');
+    expect(queueCard).toHaveStyleRule('width: 27.2rem');
   });
 
   it('render an editorial sticker', () => {

--- a/src/components/Cards/shared/PersonHeadShot/__tests__/PersonHeadShot.spec.js
+++ b/src/components/Cards/shared/PersonHeadShot/__tests__/PersonHeadShot.spec.js
@@ -28,16 +28,16 @@ describe('PersonHeadShot component should', () => {
   it('have default size of 10rem', () => {
     renderComponent();
     const headShot = screen.getByTestId('person-head-shot');
-    expect(headShot).toHaveStyle('border-radius: 50%;');
-    expect(headShot).toHaveStyle('height: 10rem;');
-    expect(headShot).toHaveStyle('width: 10rem;');
+    expect(headShot).toHaveStyleRule('border-radius: 50%;');
+    expect(headShot).toHaveStyleRule('height: 10rem;');
+    expect(headShot).toHaveStyleRule('width: 10rem;');
   });
 
   it('set size based on size prop', () => {
     renderComponent({ size: { sm: '7.2' } });
     const headShot = screen.getByTestId('person-head-shot');
-    expect(headShot).toHaveStyle('border-radius: 50%;');
-    expect(headShot).toHaveStyle('height: 7.2rem;');
-    expect(headShot).toHaveStyle('width: 7.2rem;');
+    expect(headShot).toHaveStyleRule('border-radius: 50%;');
+    expect(headShot).toHaveStyleRule('height: 7.2rem;');
+    expect(headShot).toHaveStyleRule('width: 7.2rem;');
   });
 });

--- a/src/components/Cards/shared/PersonHeadShot/index.js
+++ b/src/components/Cards/shared/PersonHeadShot/index.js
@@ -6,21 +6,26 @@ import breakpoint from 'styled-components-breakpoint';
 import { getImageUrl } from '../../../../lib/cloudinary';
 
 const PersonHeadShotWrapper = styled.div`
-  ${({ size: { sm, md, lg } }) => `
+  ${({ size: { sm } }) => `
     border-radius: 50%;
     height: ${sm}rem;
     width: ${sm}rem;
+  `}
 
-    ${breakpoint('md')`
+  ${breakpoint('md')`
+    ${({ size: { sm, md } }) => `
       height: ${md || sm}rem;
       width: ${md || sm}rem;
     `}
+  `}
 
-    ${breakpoint('lg')`
+  ${breakpoint('lg')`
+    ${({ size: { sm, md, lg } }) => `
       height: ${lg || md || sm}rem;
       width: ${lg || md || sm}rem;
     `}
   `}
+
   flex-shrink: 0;
   overflow: hidden;
 `;

--- a/src/components/Carousels/DocumentListCarousel/index.js
+++ b/src/components/Carousels/DocumentListCarousel/index.js
@@ -48,7 +48,7 @@ const CtaTheme = {
 
     ${breakpoint('md')`
       font-size: ${fontSize.md};
-      letter-spacing: ${letterSpacing.xlg};
+      letter-spacing: ${letterSpacing.cta};
     `}
   `,
   dark: css`

--- a/src/components/Gif/index.js
+++ b/src/components/Gif/index.js
@@ -165,35 +165,41 @@ class Gif extends Component {
         className={`${lazy ? 'img-lazy ' : ''}img`}
         alt={alt}
         src={getBlankImage(aspectRatio)}
+        ref={(node) => { this.node = node; }}
       />
     );
   }
 
   renderVideo() {
-    const { className, srcSet } = this.props;
+    const { alt, aspectRatio, className, srcSet } = this.props;
     return (
       <GifContainer
         className={className}
         data-testid="mise-gif"
-      >
-        {this.renderBlankImage()}
-        <video
-          autoPlay
-          loop
-          muted
-          poster={srcSet.poster}
-          ref={(node) => { this.node = node; }}
-        >
-          <source
-            type="video/mp4"
-            src={`${srcSet.mp4}.mp4`}
+        dangerouslySetInnerHTML={{ __html: `
+          <img
+            crossOrigin="anonymous"
+            className="img"
+            alt="${alt}"
+            src="${getBlankImage(aspectRatio)}"
           />
-          <source
-            type="video/webm"
-            src={`${srcSet.webm}.webm`}
-          />
-        </video>
-      </GifContainer>
+          <video
+            autoPlay
+            loop
+            muted
+            poster="${srcSet.poster}"
+          >
+            <source
+              type="video/mp4"
+              src="${`${srcSet.mp4}.mp4`}"
+            />
+            <source
+              type="video/webm"
+              src="${`${srcSet.webm}.webm`}"
+            />
+          </video>
+        ` }}
+      />
     );
   }
 

--- a/src/components/Listable/__tests__/Listable.spec.js
+++ b/src/components/Listable/__tests__/Listable.spec.js
@@ -44,6 +44,6 @@ describe('Listable component should', () => {
 
   it('change background color when selected', () => {
     renderComponent({ hasAccess: true, isSelected: true });
-    expect(screen.getByTestId('listable-body')).toHaveStyle(`background-color: ${color.eclipse};`);
+    expect(screen.getByTestId('listable-body')).toHaveStyleRule(`background-color: ${color.eclipse};`);
   });
 });

--- a/src/styles/typography.js
+++ b/src/styles/typography.js
@@ -26,6 +26,7 @@ const lineHeight = {
 };
 
 const letterSpacing = {
+  cta: '2.88px', // cta buttons for ads
   xxsm: '0.2px',
   xsm: '0.8px',
   sm: '1.0px',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,7 +1655,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.3":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -4672,10 +4672,20 @@ babel-plugin-react-docgen@^4.0.0:
     react-docgen "^5.0.0"
     recast "^0.14.7"
 
-"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.10.7:
+"babel-plugin-styled-components@>= 1":
   version "1.10.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz#3494e77914e9989b33cc2d7b3b29527a949d635c"
   integrity sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
+babel-plugin-styled-components@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.11.1.tgz#5296a9e557d736c3186be079fff27c6665d63d76"
+  integrity sha512-YwrInHyKUk1PU3avIRdiLyCpM++18Rs1NgyMXEAQC33rIXs/vro0A+stf4sT0Gf22Got+xRWB8Cm0tw+qkRzBA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.0.0"
     "@babel/helper-module-imports" "^7.0.0"
@@ -10227,10 +10237,10 @@ jest-snapshot@^26.4.1:
     pretty-format "^26.4.0"
     semver "^7.3.2"
 
-jest-styled-components@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-7.0.2.tgz#b7711871ea74a04491b12bad123fa35cc65a2a80"
-  integrity sha512-i1Qke8Jfgx0Why31q74ohVj9S2FmMLUE8bNRSoK4DgiurKkXG6HC4NPhcOLAz6VpVd9wXkPn81hOt4aAQedqsA==
+jest-styled-components@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-7.0.3.tgz#cc0b031f910484e68f175568682f3969ff774b2c"
+  integrity sha512-jj9sWyshehUnB0P9WFUaq9Bkh6RKYO8aD8lf3gUrXRwg/MRddTFk7U9D9pC4IAI3v9fbz4vmrMxwaecTpG8NKA==
   dependencies:
     css "^2.2.4"
 
@@ -15510,14 +15520,14 @@ styled-components-breakpoint@2.1.1:
   resolved "https://registry.yarnpkg.com/styled-components-breakpoint/-/styled-components-breakpoint-2.1.1.tgz#37c1b92b0e96c1bbc5d293724d7a114daaa15fca"
   integrity sha512-PkS7p3MkPJx/v930Q3MPJU8llfFJTxk8o009jl0p+OUFmVb2AlHmVclX1MBHSXk8sZYGoVTTVIPDuZCELi7QIg==
 
-styled-components@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.0.1.tgz#57782a6471031abefb2db5820a1876ae853bc619"
-  integrity sha512-E0xKTRIjTs4DyvC1MHu/EcCXIj6+ENCP8hP01koyoADF++WdBUOrSGwU1scJRw7/YaYOhDvvoad6VlMG+0j53A==
+styled-components@5.2.0, styled-components@^5:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.0.tgz#6dcb5aa8a629c84b8d5ab34b7167e3e0c6f7ed74"
+  integrity sha512-9qE8Vgp8C5cpGAIdFaQVAl89Zgx1TDM4Yf4tlHbO9cPijtpSXTMLHy9lmP0lb+yImhgPFb1AmZ1qMUubmg3HLg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^0.8.3"
+    "@emotion/is-prop-valid" "^0.8.8"
     "@emotion/stylis" "^0.8.4"
     "@emotion/unitless" "^0.7.4"
     babel-plugin-styled-components ">= 1"


### PR DESCRIPTION
* per tabitha, all ad CTA's should have the same letter spacing. This is a new value for our letter spacing scale and it's specific to CTA's - so I created a `cta` value in the scale we use to avoid some other awkward size name.
* fix text color on one ad element white -> whiteSmoke

UPDATE
There's a bug with react where it doesn't guarantee `muted` attribute on a `video` element, which is used in our `Gif` component. See:
https://medium.com/@BoltAssaults/autoplay-muted-html5-video-safari-ios-10-in-react-673ae50ba1f5
and
https://github.com/facebook/react/issues/10389

While troubleshooting this, I bumped some versions of styled components and jest libs. This revealed an change we had to make to our PersonHeadshot styles - the updated version of styled components + jest didn't like how the size rules were rendering. Moving them out into their own block (prop function inside of breakpiont vs breakpoint inside of prop function) fixes this.

Note that the newest version of `jest-styled-components` uses `toHaveStyleRule` vs `toHaveStyle`, so I updated those spots as well. Looks like we're back to all green!