### PR TITLE
play home page ad tweaks

### DIFF
--- a/src/components/Ads/PairedProductAd/index.js
+++ b/src/components/Ads/PairedProductAd/index.js
@@ -165,8 +165,12 @@ const PairedProductTitleTheme = {
   default: css`
     font: ${fontSize.xl}/${lineHeight.sm} ${font.pnb};
 
-    ${breakpoint('md')`
+    ${breakpoint('lg')`
       font: 2.6rem/${lineHeight.sm} ${font.pnb};
+
+      span {
+        white-space: nowrap;
+      }
     `}
   `,
   dark: css`
@@ -260,9 +264,9 @@ const PairedProducts = ({ title, products }) => (
             <PairedProductSubtitle>
               {subtitle}
             </PairedProductSubtitle>
-            <PairedProductTitle>
-              {title}
-            </PairedProductTitle>
+            <PairedProductTitle
+              dangerouslySetInnerHTML={{ __html: title }}
+            />
           </PairedProductInfo>
           <PairedProductCta
             href={ctaHref}

--- a/src/components/Cards/CardWrapper/index.js
+++ b/src/components/Cards/CardWrapper/index.js
@@ -44,6 +44,7 @@ const CardWrapperTitleTheme = {
   default: css`
     font: ${fontSize.xl}/1 ${font.pnb};
     margin-bottom: ${spacing.xsm};
+    white-space: nowrap;
 
     ${breakpoint('lg')`
       font-size: ${fontSize.xxl};
@@ -67,7 +68,10 @@ const CardWrapperCtaTheme = {
     font: ${fontSize.sm}/${lineHeight.sm} ${font.pnr};
     letter-spacing: ${letterSpacing.cta};
     margin-bottom: ${spacing.xsm};
+    overflow: hidden;
     text-transform: uppercase;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     &:hover {
       color: ${color.silver};


### PR DESCRIPTION
* ellipsis text for card wrapper sub component
* use nowrap in an ad to prevent awkward word-break on desktop for the paired product ad