### PR TITLE
centering next/prev vertically taking button size into account

### DIFF
--- a/src/components/Carousels/CardCarousel/index.js
+++ b/src/components/Carousels/CardCarousel/index.js
@@ -112,7 +112,7 @@ const CardCarouselTheme = {
 
       &.card-carousel--standard {
         .flickity-prev-next-button {
-          top: 13.6rem;
+          top: 11.4rem; /* vertically centered within image */
           transform: none;
         }
       }


### PR DESCRIPTION
previous change didn't account for height of the button itself so it was still half a button too low