### PR TITLE
manually remove aria-hidden on carousel cells when destroying carousel

### DIFF
--- a/src/components/Carousels/Carousel/index.js
+++ b/src/components/Carousels/Carousel/index.js
@@ -222,8 +222,13 @@ const Carousel = ({ className, dotPosition, items, options, renderItem }) => {
     if (items.length > 1 && elRef?.current) {
       const flkty = getFlickityInstance(elRef.current, opts);
       const isEnabled = flkty.slides.length > 1;
-      if (isEnabled === false) flkty.destroy();
-      else flktyRef.current = flkty;
+      if (isEnabled === false) {
+        flkty.destroy();
+        const cells = elRef.current.querySelectorAll('.carousel-cell');
+        [...cells].forEach(el => el.removeAttribute('aria-hidden'));
+      } else {
+        flktyRef.current = flkty;
+      }
       setEnabled(isEnabled);
     }
     return () => {


### PR DESCRIPTION
When flickity creates cells it adds aria-hidden and then selectively removes that attribute when cells are visible. When the instance is destroyed, there is code in Flickity source to remove the `aria-hidden` attributes. There's two problem right now: 

1) For this hero carousel, flickity isn't recognizing the three cards as visible so it's not automatically removing `aria-hidden` 
2) We destroy the instance b/c it's only one slide worth of cards but the `destroy` code in Flickity isn't removing the attributes - not sure why

So, when we destroy the flickity instance we should manually remove the `aria-hidden` from all cells.