### PR TITLE
carousel gradient fixes for safari

### DIFF
--- a/src/components/Buttons/ActionButtons/FavoriteActionButton/index.js
+++ b/src/components/Buttons/ActionButtons/FavoriteActionButton/index.js
@@ -5,7 +5,9 @@ import Button from '../../Button';
 import { color, letterSpacing, font, fontSize, spacing } from '../../../../styles';
 import { ChevronThinDown, FavoriteRibbon, Folder } from '../../../DesignTokens/Icon/svgs';
 
-const ButtonWrapper = styled.div`
+const ButtonWrapper = styled.div.attrs({
+  className: 'favorite-action-wrapper',
+})`
   align-items: center;
   display: inline-flex;
   justify-content: center;

--- a/src/components/Carousels/CardCarousel/index.js
+++ b/src/components/Carousels/CardCarousel/index.js
@@ -74,6 +74,7 @@ const CardCarouselTheme = {
     }
 
     .flickity-enabled ~ .linear-gradient {
+      display: block;
       height: 100%;
       position: absolute;
       right: 0;

--- a/src/components/DesignTokens/LinearGradient/index.js
+++ b/src/components/DesignTokens/LinearGradient/index.js
@@ -10,19 +10,23 @@ const LinearGradientTheme = {
     background-image: ${({ angle, startColor, endColor, stop }) => `linear-gradient(${angle}deg, ${color[startColor]} 0, ${color[endColor]} ${stop})`};
 
     .jet-gradient & {
-      ${({ angle, stop }) => `background-image: linear-gradient(${angle}deg, transparent 0, ${color.jet} ${stop});`}
+      ${({ angle, stop }) => `background-image: linear-gradient(${angle}deg, rgba(8, 8, 8, 0) 0, rgba(8, 8, 8, 1) ${stop});`}
     }
 
     .gunmetal-gradient & {
-      ${({ angle, stop }) => `background-image: linear-gradient(${angle}deg, transparent 0, ${color.gunmetal} ${stop});`}
+      ${({ angle, stop }) => `background-image: linear-gradient(${angle}deg, rgba(38, 38, 38, 0) 0, rgba(38, 38, 38, 1) ${stop});`}
     }
 
     .asphalt-gradient & {
-      ${({ angle, stop }) => `background-image: linear-gradient(${angle}deg, transparent 0, ${color.asphalt} ${stop});`}
+      ${({ angle, stop }) => `background-image: linear-gradient(${angle}deg, rgba(25, 25, 25, 0) 0, rgba(25, 25, 25, 1) ${stop});`}
+    }
+
+    .whitesmoke-gradient & {
+      ${({ angle, stop }) => `background-image: linear-gradient(${angle}deg, rgba(245, 245, 245, 0) 0, rgba(245, 245, 245, 1) ${stop});`}
     }
   `,
   dark: css`
-    background-image: ${({ angle, stop }) => `linear-gradient(${angle}deg, transparent, ${color.gunmetal} ${stop})`};
+    background-image: ${({ angle, stop }) => `linear-gradient(${angle}deg, rgba(38, 38, 38, 0) 0, rgba(38, 38, 38, 1) ${stop})`};
   `,
 };
 


### PR DESCRIPTION
* ATK has a `display: none` for empty divs in some contexts, so we can add `display: block` in `CardCarousel`
* classname for button wrapper to help with styling from `espresso`
* Safari gradients don't look right unless you use the full rgba notation. I thought about using variables but these are the only place this problem exists b/c it's specific to gradients in safari. I don't see the value in defining these as external variables..but I could be persuaded to change my mind if someone was really 😠 about this.