### PR TITLE
allow editorial stickers on FeatureCard to render icons when priority sticker is present

### DIFF
--- a/src/components/Cards/FeatureCard/index.js
+++ b/src/components/Cards/FeatureCard/index.js
@@ -185,12 +185,11 @@ function FeatureCard({
           >
             { stickers ? (
               <StickerGroup>
-                {stickers.map(({ text, type }, idx) => (
+                {stickers.map(({ text, type }) => (
                   <StyledSticker
                     className={className}
                     key={text}
                     contentType={contentType}
-                    icon={idx === 0}
                     type={type}
                     text={text}
                   />


### PR DESCRIPTION
duration stickers on watch home page were not rendering VideoPlay when 'new' sticker was present