### PR TITLE
limit width of text and dots on loading carousel

### DIFF
--- a/src/components/Carousels/LoadingCarousel/index.js
+++ b/src/components/Carousels/LoadingCarousel/index.js
@@ -35,7 +35,7 @@ const StyledLoadingCarousel = styled.div`
     }
 
     ${breakpoint('md')`
-      width: 115rem;
+      max-width: 115rem;
 
       .title-and-cta {
         width: 61.2rem;


### PR DESCRIPTION
the width was pushing the page past the screen on tablet