### PR TITLE
Don't scale stickers with hover and active states

### DIFF
--- a/src/components/Cards/PodcastEpisodeCard/index.js
+++ b/src/components/Cards/PodcastEpisodeCard/index.js
@@ -261,6 +261,13 @@ class PodcastEpisodeCard extends Component {
               imageAlt={imageAlt}
               imageUrl={imageUrl}
             />
+          </ImageWrapper>
+        </div>
+        <div>
+          <div className="place-hold">
+            <StyledBadge
+              type={siteKey}
+            />
             {stickers.map(({ text, type }) => (
               <StyledSticker
                 key={text}
@@ -269,13 +276,6 @@ class PodcastEpisodeCard extends Component {
                 text={text}
               />
             ))}
-          </ImageWrapper>
-        </div>
-        <div>
-          <div className="place-hold">
-            <StyledBadge
-              type={siteKey}
-            />
           </div>
           <TextWrapper>
             <button


### PR DESCRIPTION
The way github is showing the diff is kind of weird/confusing, but really I am moving the stickers out of `.grow-div` so they don't scale up on the hover and active states. 