### PR TITLE
update gifs for ads, no animations on showcase gif ad icons

### DIFF
--- a/src/components/Ads/ShowcaseAds/MembershipShowcaseAd/index.js
+++ b/src/components/Ads/ShowcaseAds/MembershipShowcaseAd/index.js
@@ -121,9 +121,9 @@ const deviceConfigMap = {
 };
 
 const deviceIdMap = {
-  desktop: 'mise-play/membership-showcase-desktop',
-  tablet: 'mise-play/membership-showcase-tablet',
-  phone: 'mise-play/membership-showcase-desktop',
+  desktop: 'mise-play/membership-showcase-desktop-2',
+  tablet: 'mise-play/membership-showcase-tablet-2',
+  phone: 'mise-play/membership-showcase-desktop-2',
 };
 
 const MembershipShowcaseAd = ({
@@ -146,7 +146,9 @@ const MembershipShowcaseAd = ({
       <MembershipShowcaseTitle>
         {title()}
       </MembershipShowcaseTitle>
-      <MembershipBenefitIcons />
+      <MembershipBenefitIcons
+        animated={false}
+      />
       <MembershipCta
         href={ctaHref}
         onClick={onClick}

--- a/src/components/Ads/ShowcaseAds/SchoolAd/index.js
+++ b/src/components/Ads/ShowcaseAds/SchoolAd/index.js
@@ -188,9 +188,9 @@ const deviceConfigMap = {
 };
 
 const deviceIdMap = {
-  desktop: 'mise-play/membership-showcase-desktop',
-  tablet: 'mise-play/membership-showcase-tablet',
-  phone: 'mise-play/membership-showcase-tablet',
+  desktop: 'mise-play/membership-showcase-desktop-2',
+  tablet: 'mise-play/membership-showcase-tablet-2',
+  phone: 'mise-play/membership-showcase-tablet-2',
 };
 
 const SchoolAd = ({

--- a/src/components/Ads/components/MembershipBenefitsIcons.js
+++ b/src/components/Ads/components/MembershipBenefitsIcons.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import { Cookbook, Phone, RecipeCard, RibbonAward, Videos } from '../../DesignTokens/Icon/svgs';
@@ -63,7 +64,7 @@ const Benefit = styled.div`
 `;
 
 const CircularIcon = styled.div`
-  animation: pulse 6s infinite ease-in-out;
+  ${({ animated }) => (animated ? 'animation: pulse 6s infinite ease-in-out;' : '')}
   background-color: ${color.black};
   border-radius: 50%;
   display: inline-block;
@@ -102,7 +103,7 @@ const CircularIcon = styled.div`
   }
 `;
 
-const MembershipBenefitsIcons = () => (
+const MembershipBenefitsIcons = ({ animated }) => (
   <MembershipBenefitsIconsWrapper
     data-testid="benefit-icons"
   >
@@ -114,6 +115,7 @@ const MembershipBenefitsIcons = () => (
           key={benefit.icon}
         >
           <CircularIcon
+            animated={animated}
             style={{ animationDelay: `${idx}s` }}
           >
             {renderIcon(benefit.icon)}
@@ -126,5 +128,13 @@ const MembershipBenefitsIcons = () => (
     }
   </MembershipBenefitsIconsWrapper>
 );
+
+MembershipBenefitsIcons.propTypes = {
+  animated: PropTypes.bool,
+};
+
+MembershipBenefitsIcons.defaultProps = {
+  animated: true,
+};
 
 export default MembershipBenefitsIcons;


### PR DESCRIPTION
* animated gifs with animated icons is too much happening all at once - option to disable animations
* updated cloudinary ids for the ads