### PR TITLE
adjust default carousel arrow styles

### DIFF
--- a/src/styles/carousel.js
+++ b/src/styles/carousel.js
@@ -48,13 +48,13 @@ export default css`
 
   .flickity-button {
     position: absolute;
-    background: hsla(0, 0%, 100%, 0.75);
+    background: none;
     border: none;
     color: #333;
   }
 
   .flickity-button:hover {
-    background: white;
+    background: none;
     cursor: pointer;
   }
 


### PR DESCRIPTION
These styles are included in `espresso`/`jarvis` where we don't want background color on the arrows. 