### PR TITLE
only increase podcast episode card on larger screens

### DIFF
--- a/src/components/Cards/PodcastEpisodeCard/index.js
+++ b/src/components/Cards/PodcastEpisodeCard/index.js
@@ -38,12 +38,20 @@ const PodcastEpisodeCardWrapper = styled.div`
       .grow-div {
         background-color: ${color.jet};
         box-shadow: 0 7px 8px -2px ${color.transparentBlack};
-        transform: scale(1.05);
       }
     }
 
     p {
       display: none;
+    }
+  `}
+
+  ${breakpoint('lg')`
+    &:hover,
+    &.is-playing {
+      .grow-div {
+        transform: scale(1.05);
+      }
     }
   `}
 


### PR DESCRIPTION
the size increase of the selected podcast episode card made the entire podcast show page shift a littttle to the right on tablet portrait breakpoint