### PR TITLE
hero gradient in css

### DIFF
--- a/src/components/Cards/HeroCard/index.js
+++ b/src/components/Cards/HeroCard/index.js
@@ -13,8 +13,8 @@ import { VideoPlay } from '../../DesignTokens/Icon/svgs';
 const HeroCardWrapper = styled.div.attrs({
   className: 'hero-card',
 })`
-  background-image: ${({ backgroundImg, withGradient }) => `${withGradient ? `linear-gradient(to bottom, rgba(0, 0, 0, 0), ${color.black}), ` : ''}url("${backgroundImg}")`};
-  background-position: center;
+  background-image: ${({ backgroundImg }) => `url("${backgroundImg}")`};
+  background-position: bottom center;
   background-size: cover;
   display: flex;
   flex-direction: column;
@@ -96,6 +96,7 @@ const HeroCardDescription = styled.div`
 `;
 
 const HeroCardLink = styled.a`
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(8, 8, 8, 1));
   display: flex;
   flex-direction: column;
   flex: 1 0 0;
@@ -152,11 +153,9 @@ const HeroCard = ({
 }) => {
   const Logo = keyToLogo(iconKey);
   const backgroundImg = getImageUrl(backgroundCloudinaryId, 'heroCard');
-  const withGradient = backgroundCloudinaryId.startsWith('http');
   return (
     <HeroCardWrapper
       backgroundImg={backgroundImg}
-      withGradient={withGradient}
     >
       <HeroCardLink
         href={ctaUrl}

--- a/src/components/Carousels/LoadingCarousel/index.js
+++ b/src/components/Carousels/LoadingCarousel/index.js
@@ -17,7 +17,7 @@ const StyledLoadingCarousel = styled.div`
     `}
   }
 
-  .text-and-dots { 
+  .text-and-dots {
     display: flex;
     height: 2.1rem;
     justify-content: space-between;
@@ -72,7 +72,7 @@ const StyledLoadingCarousel = styled.div`
           width: 4rem;
         }
     `}
-    
+
   }
 `;
 
@@ -112,7 +112,7 @@ LoadingCarousel.propTypes = {
   /** Larger title displayed above carousel */
   title: PropTypes.string,
   /** Sets the carousel-item styles for a particular card style */
-  type: PropTypes.oneOf(['standard', 'feature', 'tall']).isRequired,
+  type: PropTypes.oneOf(['standard', 'feature', 'person', 'tall']).isRequired,
 };
 
 LoadingCarousel.defaultProps = {

--- a/src/lib/cloudinary/index.js
+++ b/src/lib/cloudinary/index.js
@@ -82,7 +82,6 @@ const imageConfig = {
   heroCard() {
     return {
       ...baseImageConfig,
-      ...imageConfig.gradientFade(),
     };
   },
   pairedProduct() {


### PR DESCRIPTION
Hero image aspect ratio varies greatly based on screen size - not just device type. This means that the gradient we're building into the image might not be visible when we're going center/center with the bg image. Pushing the image to bottom/center isn't a great solution either since the image is sometimes cropped around faces or people, which are centered in the screen. Best solution is to separate the gradient and the image generation and leave the center/center on the image.

Also, fixing a warning about loading carousel card type of `person`