### PR TITLE
play-light carousel arrow color, standard card height increase, membership ad version

### DIFF
--- a/src/components/Ads/ShowcaseAds/MembershipShowcaseAd/index.js
+++ b/src/components/Ads/ShowcaseAds/MembershipShowcaseAd/index.js
@@ -121,9 +121,9 @@ const deviceConfigMap = {
 };
 
 const deviceIdMap = {
-  desktop: 'mise-play/membership-showcase-desktop-2',
-  tablet: 'mise-play/membership-showcase-tablet-2',
-  phone: 'mise-play/membership-showcase-desktop-2',
+  desktop: 'mise-play/membership-showcase-desktop-3',
+  tablet: 'mise-play/membership-showcase-tablet-3',
+  phone: 'mise-play/membership-showcase-desktop-3',
 };
 
 const MembershipShowcaseAd = ({

--- a/src/components/Carousels/CardCarousel/index.js
+++ b/src/components/Carousels/CardCarousel/index.js
@@ -33,7 +33,7 @@ const typeHeights = {
     hero: '46.5rem',
     tall: '60rem',
     person: '27.2rem',
-    default: '40rem',
+    default: '41rem',
   },
 };
 

--- a/src/components/Carousels/Carousel/index.js
+++ b/src/components/Carousels/Carousel/index.js
@@ -129,6 +129,11 @@ const CarouselTheme = {
       }
     }
   `,
+  light: css`
+    .flickity-button {
+      color: ${color.eclipse};
+    }
+  `,
 };
 
 const CarouselWrapper = styled.div`


### PR DESCRIPTION
* skills detail bottom of the page has play-light theme. The arrow color should be eclipse.
* standard card - descenders are getting cut off in some situations
* new membership ad w/updated image of the app