### PR TITLE
align hero bg center now that fade is done via css

### DIFF
--- a/src/components/Cards/HeroCard/index.js
+++ b/src/components/Cards/HeroCard/index.js
@@ -14,7 +14,7 @@ const HeroCardWrapper = styled.div.attrs({
   className: 'hero-card',
 })`
   background-image: ${({ backgroundImg }) => `url("${backgroundImg}")`};
-  background-position: bottom center;
+  background-position: center center;
   background-size: cover;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
When the fade was in the image itself we had to have this bottom aligned so that we could see the fade. We swapped the fade to css so that we didn't have to anchor to the bottom - I must have missed this in my commit. Center is better b/c that's where cloudinary will be cropping to.