### PR TITLE
display fixes for school showcase ad

### DIFF
--- a/src/components/Ads/ShowcaseAds/SchoolAd/index.js
+++ b/src/components/Ads/ShowcaseAds/SchoolAd/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-import Badge from '../../../Badge';
 import Gif from '../../../Gif';
 import { getImageUrl, getGifSrcSet } from '../../../../lib/cloudinary';
 import {
@@ -23,12 +22,6 @@ const SchoolTheme = {
   dark: css`
     background-color: ${color.mineShaft};
     position: relative;
-
-    .badge {
-      left: ${spacing.xsm};
-      position: absolute;
-      top: ${spacing.xsm};
-    }
 
     ${breakpoint('md')`
       align-items: center;
@@ -191,7 +184,7 @@ const deviceConfigMap = {
 const deviceIdMap = {
   desktop: 'mise-play/school-showcase-desktop-3',
   tablet: 'mise-play/school-showcase-tablet-3',
-  phone: 'mise-play/school-showcase-tablet-3',
+  phone: 'mise-play/school-showcase-desktop-3',
 };
 
 const SchoolAd = ({
@@ -200,7 +193,6 @@ const SchoolAd = ({
   ctaTarget,
   deviceType,
   onClick,
-  siteKey,
   subtitle,
   title,
 }) => (
@@ -238,9 +230,6 @@ const SchoolAd = ({
         </SchoolCta>
       </SchoolInfoInner>
     </SchoolInfo>
-    <Badge
-      type={siteKey}
-    />
   </School>
 );
 
@@ -250,7 +239,6 @@ SchoolAd.propTypes = {
   ctaTarget: PropTypes.string,
   deviceType: PropTypes.oneOf(['desktop', 'phone', 'tablet']).isRequired,
   onClick: PropTypes.func,
-  siteKey: PropTypes.oneOf(['atk', 'cio', 'cco', 'kids', 'school', 'shop']).isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
 };

--- a/src/lib/cloudinary/index.js
+++ b/src/lib/cloudinary/index.js
@@ -131,24 +131,18 @@ const imageConfig = {
   },
   showcaseSchoolAdMobile() {
     return {
-      aspectRatio: '34:33',
-      gravity: 'south_west',
       secure: true,
       width: 375,
     };
   },
   showcaseSchoolAdTablet() {
     return {
-      aspectRatio: '34:33',
-      gravity: 'south_west',
       secure: true,
       width: 300,
     };
   },
   showcaseSchoolAdDesktop() {
     return {
-      aspectRatio: '56:33',
-      gravity: 'south_west',
       secure: true,
       width: 500,
     };


### PR DESCRIPTION
Badge is included in the gif, so should be excluded form source. The cropping on the gif was causing issues so if we exclude gravity and aspect ratio we get the proper proportions.