### PR TITLE
Add custom focus indicator to radio and checkbox search filters

### DIFF
--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -17,7 +17,7 @@ const AccordionButtonTheme = {
     font: ${fontSize.md}/1 ${font.pnb};
     justify-content: space-between;
     letter-spacing: ${letterSpacing.md};
-    padding: ${spacing.xsm} ${spacing.xxsm} ${spacing.xsm} 0;
+    padding: 0.2rem ${spacing.xxsm} 0.2rem 0;
     text-transform: uppercase;
     width: 100%;
 

--- a/src/components/Algolia/shared/RefinementFilter/RefinementFilter.js
+++ b/src/components/Algolia/shared/RefinementFilter/RefinementFilter.js
@@ -4,19 +4,21 @@ import styled, { css } from 'styled-components';
 
 import Badge from '../../../Badge';
 import { Checkmark } from '../../../DesignTokens/Icon/svgs';
-import { color, font, fontSize, lineHeight, spacing, withThemes } from '../../../../styles';
+import { color, font, fontSize, spacing, withThemes } from '../../../../styles';
 
 const RefinementFilterLabelTheme = {
   default: css`
     align-items: center;
+    border: 1px dashed transparent;
     color: ${color.eclipse};
     display: flex;
     font: ${fontSize.md}/1.38 ${font.pnr};
-    margin-bottom: 1.2rem;
+    padding: ${spacing.xxsm} 0.25rem ${spacing.xxsm} 2.5rem;
+    left: -2.5rem;
     position: relative;
 
     &.search_site_list {
-      margin-bottom: 1.8rem;
+      padding: ${spacing.xsm} 0.25rem ${spacing.xsm} 2.5rem;
     }
 
     .search-refinement-list__label-text {
@@ -37,15 +39,22 @@ const RefinementFilterLabelTheme = {
       }
     }
 
+    &:focus-within {
+      border: 1px dashed ${color.eclipse};
+    }
+
     .search-refinement__badge {
       margin-right: 0.8rem;
     }
   `,
   kidsSearch: css`
     background-color: ${color.greySmoke};
+    border: 2px solid transparent;
     border-radius: 1rem;
     color: ${color.black};
-    line-height: ${lineHeight.xlg};
+    left: 0;
+    line-height: 1.37;
+    margin-bottom: 1.2rem;
     padding: 0.4rem 1.3rem;
 
     .search-refinement-list__label-text {
@@ -82,6 +91,10 @@ const RefinementFilterLabelTheme = {
         }
       }
     ` : '')}
+
+    &:focus-within {
+      border: 2px solid ${color.jade};
+    }
   `,
   dark: css`
     color: ${color.white};
@@ -169,7 +182,7 @@ const RefinementFilter = ({
   handleClick,
   value,
 }) => (
-  <li>
+  <>
     <RefinementFilterLabel
       altFill={altFill}
       className={`${attribute}`}
@@ -217,7 +230,7 @@ const RefinementFilter = ({
         )
       }
     </RefinementFilterLabel>
-  </li>
+  </>
 );
 
 RefinementFilter.propTypes = {

--- a/src/components/Algolia/shared/RefinementList/index.js
+++ b/src/components/Algolia/shared/RefinementList/index.js
@@ -6,7 +6,7 @@ import ShowMoreLess from '../../../ShowMoreLess';
 import RefinementFilter from '../RefinementFilter/RefinementFilter';
 import { color } from '../../../../styles';
 
-const RefinementListRefinements = styled.ul`
+const RefinementListRefinements = styled.div`
   border: none;
   margin: 0;
   padding: 0;

--- a/src/components/Algolia/shared/SortBy/index.js
+++ b/src/components/Algolia/shared/SortBy/index.js
@@ -12,31 +12,8 @@ import {
   withThemes,
 } from '../../../../styles';
 
-const SearchSortByList = styled.ul``;
-
 const SearchSortByItemTheme = {
   default: css`
-    margin-bottom: ${spacing.sm};
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  `,
-  kidsSearch: css`
-    margin-bottom: ${spacing.xsm};
-  `,
-};
-
-const SearchSortByItem = styled.li`
-  ${withThemes(SearchSortByItemTheme)}
-`;
-
-const SearchSortByButtonTheme = {
-  default: css`
-    align-items: center;
-    display: flex;
-    letter-spacing: normal;
-
     &:hover {
       cursor: pointer;
 
@@ -51,40 +28,31 @@ const SearchSortByButtonTheme = {
     }
   `,
   kidsSearch: css`
-    background-color: ${color.greySmoke};
-    border-radius: 1rem;
-    color: ${color.black};
-    display: block;
-    line-height: ${lineHeight.xlg};
-    text-align: left;
-    padding: 0.4rem 1.3rem;
-    width: 100%;
-
-    .search-sort-by__label {
-      color: ${color.black};
-    }
+    margin-bottom: ${spacing.xsm};
 
     &:hover {
-      box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
-
       .search-sort-by__label {
         color: ${color.black};
-      }
-    }
-
-    &.refined {
-      background-color: ${color.jade};
-
-      .search-sort-by__label {
-        color: ${color.white};
-        font-family: ${font.pnb};
       }
     }
   `,
 };
 
-const SearchSortByButton = styled.button`
-  ${withThemes(SearchSortByButtonTheme)}
+const SearchSortByItem = styled.div`
+  ${withThemes(SearchSortByItemTheme)}
+`;
+
+const SearchSortByRadioInputTheme = {
+  default: css`
+    position: absolute;
+    opacity: 0;
+  `,
+  kidsSearch: css`
+  `,
+};
+
+const SearchSortByRadioInput = styled.input`
+  ${withThemes(SearchSortByRadioInputTheme)}
 `;
 
 const SearchSortByCircleTheme = {
@@ -112,38 +80,91 @@ const SearchSortByCircle = styled.div.attrs({
 
 const SearchSortByLabelTheme = {
   default: css`
+    align-items: center;
+    border: 1px dashed transparent;
     color: ${color.eclipse};
+    display: flex;
     font: ${fontSize.md}/1.38 ${font.pnr};
     font-size: ${fontSize.md};
+    left: -2.5rem;
+    letter-spacing: normal;
+    padding: ${spacing.xxsm} 0.25rem ${spacing.xxsm} 2.5rem;
+    position: relative;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &:focus-within {
+      border: 1px dashed ${color.eclipse};
+    }
   `,
-  kidsSearch: css``,
+  kidsSearch: css`
+    background-color: ${color.greySmoke};
+    border: 2px solid transparent;
+    border-radius: 1rem;
+    color: ${color.black};
+    display: block;
+    left: 0;
+    line-height: ${lineHeight.sm};
+    text-align: left;
+    padding: 0.4rem 1.3rem;
+    width: 100%;
+
+    .search-sort-by__label {
+      color: ${color.black};
+    }
+
+    &:hover {
+      box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
+    }
+
+    ${({ isRefined }) => (isRefined ? `
+      background-color: ${color.jade};
+      color: ${color.white};
+      font-family: ${font.pnb};
+
+      &:hover {
+        color: ${color.white};
+      }
+    ` : '')}
+
+    &:focus-within {
+      border: 2px solid ${color.jade};
+    }
+  `,
 };
 
-const SearchSortByLabel = styled.span.attrs({
+const SearchSortByLabel = styled.label.attrs({
   className: 'search-sort-by__label',
 })`${withThemes(SearchSortByLabelTheme)}`;
 
 export const CustomSortBy = ({ items, refine }) => (
-  <SearchSortByList>
+  <>
     {
       items.map(({ isRefined, label, value }) => (
-        <SearchSortByItem key={value}>
-          <SearchSortByButton
-            className={isRefined ? 'refined' : ''}
-            onClick={(e) => { e.preventDefault(); refine(value); }}
+        <SearchSortByItem
+          key={value}
+        >
+          <SearchSortByLabel
+            isRefined={isRefined}
           >
+            <SearchSortByRadioInput
+              checked={isRefined}
+              className={isRefined ? 'refined' : ''}
+              onClick={(e) => { e.preventDefault(); refine(value); }}
+              type="radio"
+            />
             <SearchSortByCircle
               data-testid="sort-by__radio"
               isRefined={isRefined}
             />
-            <SearchSortByLabel>
-              {label}
-            </SearchSortByLabel>
-          </SearchSortByButton>
+            {label}
+          </SearchSortByLabel>
         </SearchSortByItem>
       ))
     }
-  </SearchSortByList>
+  </>
 );
 
 CustomSortBy.propTypes = {

--- a/src/components/ShowMoreLess/index.js
+++ b/src/components/ShowMoreLess/index.js
@@ -4,19 +4,15 @@ import styled, { css } from 'styled-components';
 
 import { color, font, spacing, withThemes } from '../../styles';
 
-const ShowMoreLessInitial = styled.ul`
-  margin-bottom: ${spacing.xsm};
-`;
-
-const ShowMoreLessRest = styled.ul`
-  margin-bottom: 1.2rem;
-`;
+const ShowMoreLessInitial = styled.div``;
+const ShowMoreLessRest = styled.div``;
 
 export const ShowMoreLessButtonTheme = {
   default: css`
     color: ${color.nobel};
     font: 1.2rem/1 ${font.pnb};
     letter-spacing: 1.2px;
+    padding: ${spacing.xsm} 0;
     text-transform: uppercase;
 
     &:hover {


### PR DESCRIPTION
This adds a focus indicator to the search filters in regular search and also Kids search. Since we hide the actual inputs, I used the `:focus-within` pseudo selector, which allows you to add a custom focus indicator to the parent of an input that is in focus.

I had to restructure the markup a bit to use radio and checkbox inputs, so it required some moving styles around for kids search too.