### PR TITLE
add playsinline attr to Gif for mobile safari

### DIFF
--- a/src/components/Gif/index.js
+++ b/src/components/Gif/index.js
@@ -187,6 +187,7 @@ class Gif extends Component {
             autoPlay
             loop
             muted
+            playsinline
             poster="${srcSet.poster}"
           >
             <source


### PR DESCRIPTION
The Gif for the school ad on `/skills` isnt auto playing on certain iOS versions in Safari. Apple suggests adding `playsinline` to `autoplay` `<video>`s: https://developer.apple.com/documentation/webkit/safari_tools_and_features/delivering_video_content_for_safari