### PR TITLE
disable/enable flickty when switching between portrait and landscape mode on tablet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atk/mise-ui",
-  "version": "1.1.1-canary.3fbc60b0.0",
+  "version": "1.1.4-canary.a1e1247b.0",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "algoliasearch": "^4.0.3",

--- a/src/components/Carousels/Carousel/index.js
+++ b/src/components/Carousels/Carousel/index.js
@@ -2,6 +2,7 @@ import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
+import throttle from 'lodash.throttle';
 
 import { color, spacing, withThemes } from '../../../styles';
 
@@ -231,6 +232,7 @@ const Carousel = ({ className, dotPosition, items, options, renderItem }) => {
   const [enabled, setEnabled] = useState(false);
   const opts = { ...defaultOptions, ...options };
   const { slideshow } = opts;
+  const [windowWidth, setWindowWidth] = useState(0);
 
   useEffect(() => {
     if (flktyRef.current) flktyRef.current.destroy();
@@ -251,6 +253,24 @@ const Carousel = ({ className, dotPosition, items, options, renderItem }) => {
       catch (err) {}; // eslint-disable-line
     };
   }, [items, opts]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && items.length <= 3) {
+      const handleResize = throttle(() => { setWindowWidth(window.innerWidth); }, 150);
+      window.addEventListener('resize', handleResize);
+      return () => window.removeEventListener('resize', handleResize);
+    }
+    return null;
+  }, []);
+
+  // enable/disable flickity when switching between portrait and landscape mode on tablet
+  useEffect(() => {
+    if (windowWidth > 768 && items.length < 3) {
+      setEnabled(false);
+    } else if (windowWidth < 768 && items.length >= 3) {
+      setEnabled(true);
+    }
+  }, [windowWidth]);
 
   return (
     <CarouselWrapper


### PR DESCRIPTION
the "carousel" gets stuck when you switch between tablet landscape and portrait since the number of slides changes between the breakpoints