### PR TITLE
ARCHIE-1991: add aria hidden option to Badge component

### DIFF
--- a/src/components/Badge/__tests__/__snapshots__/Badge.spec.js.snap
+++ b/src/components/Badge/__tests__/__snapshots__/Badge.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`components renders a cco badge 1`] = `
 <svg
+  aria-hidden={false}
   aria-label="CCO"
   className="sc-bdnylx nmOjv badge"
   data-testid="badge"
@@ -70,6 +71,7 @@ exports[`components renders a cco badge 1`] = `
 
 exports[`components renders a cio badge 1`] = `
 <svg
+  aria-hidden={false}
   aria-label="CIO"
   className="sc-bdnylx nmOjv badge"
   data-testid="badge"
@@ -92,6 +94,7 @@ exports[`components renders a cio badge 1`] = `
 
 exports[`components renders a kids badge 1`] = `
 <svg
+  aria-hidden={false}
   aria-label="KIDS"
   className="sc-bdnylx nmOjv badge"
   data-testid="badge"
@@ -152,6 +155,7 @@ exports[`components renders a kids badge 1`] = `
 
 exports[`components renders an atk badge 1`] = `
 <svg
+  aria-hidden={false}
   aria-label="ATK"
   className="sc-bdnylx nmOjv badge"
   data-testid="badge"

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -40,14 +40,16 @@ const determineType = (type, fill) => {
  */
 
 const Badge = ({
+  ariaHidden,
   className,
   fill,
   type,
 }) => (
   <StyledBadge
+    aria-hidden={ariaHidden}
     data-testid="badge"
     role="img"
-    aria-label={`${type}`.toUpperCase()}
+    aria-label={!ariaHidden ? `${type}`.toUpperCase() : null}
     className={`badge${className ? ` ${className}` : ''}`}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 25 25"
@@ -57,12 +59,14 @@ const Badge = ({
 );
 
 Badge.propTypes = {
+  ariaHidden: PropTypes.bool,
   className: PropTypes.string,
   fill: PropTypes.string,
   type: PropTypes.oneOf(['atk', 'cio', 'cco', 'kids', 'school', 'shop']).isRequired,
 };
 
 Badge.defaultProps = {
+  ariaHidden: false,
   className: '',
   fill: `${color.transparentBlack}`,
 };


### PR DESCRIPTION
need option to hide this badge from screen readers if it is present on a card that also has a separate logo