### PR TITLE
prop for lazy image loading, fix z-index of cta link

### DIFF
--- a/src/components/Cards/FeatureCard/index.js
+++ b/src/components/Cards/FeatureCard/index.js
@@ -122,6 +122,7 @@ const CtaLink = styled.a`
   font: ${fontSize.md}/${lineHeight.sm} ${font.pnb};
   left: ${spacing.xsm};
   position: absolute;
+  z-index: 1;
 `;
 
 function FeatureCard({
@@ -137,6 +138,7 @@ function FeatureCard({
   imageUrl,
   isFavorited,
   isWide,
+  lazyImage,
   objectId,
   onClick,
   personHeadShot,
@@ -165,6 +167,7 @@ function FeatureCard({
           className={`${className} feature-card__background-img`}
           imageAlt={imageAlt}
           imageUrl={imageUrl}
+          lazy={lazyImage}
         />
         <StyledBadge
           className={className}
@@ -248,6 +251,7 @@ FeatureCard.propTypes = {
   imageUrl: PropTypes.string.isRequired,
   isFavorited: PropTypes.bool,
   isWide: PropTypes.bool,
+  lazyImage: PropTypes.bool,
   objectId: PropTypes.string.isRequired,
   onClick: PropTypes.func,
   /** Optional: Image data that is used to render a PersonHeadShot. */
@@ -271,6 +275,7 @@ FeatureCard.defaultProps = {
   imageAlt: '',
   isFavorited: false,
   isWide: false,
+  lazyImage: true,
   onClick: null,
   personHeadShot: null,
   siteKeyFavorites: null,

--- a/src/components/EditorsNote/index.js
+++ b/src/components/EditorsNote/index.js
@@ -48,7 +48,6 @@ const EditorNote = styled.section`
   ${withThemes(EditorNoteTheme)}
 `;
 
-
 const EditorNoteIconTheme = {
   default: css`
     align-items: center;
@@ -82,7 +81,6 @@ const EditorNoteIcon = styled.span`
   ${withThemes(EditorNoteIconTheme)}
 `;
 
-
 const EditorNoteTitleTheme = {
   default: css`
     color: ${color.cuttySark};
@@ -107,7 +105,6 @@ const EditorNoteTitle = styled.span`
   ${withThemes(EditorNoteTitleTheme)}
 `;
 
-
 const EditorNoteSubtitleTheme = {
   default: css`
     font: ${fontSize.md}/${lineHeight.md} ${font.pnr};
@@ -123,7 +120,6 @@ const EditorNoteSubtitleTheme = {
 const EditorNoteSubtitle = styled.span`
   ${withThemes(EditorNoteSubtitleTheme)}
 `;
-
 
 const EditorNoteTextTheme = {
   default: css`


### PR DESCRIPTION
* Allow for images to be lazy or not lazy for feature cards
* Add a z-index so the cta appears above the gradient shadow