### PR TITLE
ARCHIE-2107 - load images when printing

### DIFF
--- a/src/components/Cards/RelatedDocumentCard/__tests__/RelatedDocumentCard.spec.js
+++ b/src/components/Cards/RelatedDocumentCard/__tests__/RelatedDocumentCard.spec.js
@@ -14,6 +14,7 @@ describe('RelatedDocumentCard component should', () => {
         <RelatedDocumentCard
           attribution="AMERICA’S TEST KITCHEN"
           contentType="episode"
+          imageAlt="this is a test, only a test"
           imageUrl="https://res.cloudinary.com/hksqkdlah/image/upload/c_fill,f_auto,g_faces:auto,q_auto:low,w_300,ar_16:9/v1592840035/mise-play/feature-card-wide.jpg"
           siteKey="atk"
           stickers={[{ type: 'priority', text: 'New' }, { type: 'editorial', text: '28:03' }]}

--- a/src/components/hooks/useMedia.js
+++ b/src/components/hooks/useMedia.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+const hasMedia = typeof window !== 'undefined' && window.matchMedia;
+
+function useMedia(query) {
+  const defaultValue = hasMedia ? window.matchMedia(query)?.matches : false;
+  const [matches, setMatches] = useState(defaultValue);
+
+  useEffect(() => {
+    const media = hasMedia ? window.matchMedia(query) : false;
+    if (media.matches !== matches) {
+      setMatches(media.matches);
+    }
+    if (media) {
+      const listener = () => setMatches(media.matches);
+      media.addListener(listener);
+      return () => media.removeListener(listener);
+    }
+    return () => {};
+  }, [query]);
+
+  return matches;
+}
+
+export default useMedia;


### PR DESCRIPTION
`useMedia` hook which lets us listen for change to print view...or breakpoints if we want.

Load images when we go into print mode using the custom dry event with media hook as fallback.