### PR TITLE
ARCHIE-2116 - adjust logic for the winner sticker

### DIFF
--- a/src/components/Cards/FeatureCard/index.js
+++ b/src/components/Cards/FeatureCard/index.js
@@ -122,7 +122,7 @@ const CtaLink = styled.a`
   font: ${fontSize.md}/${lineHeight.sm} ${font.pnb};
   left: ${spacing.xsm};
   position: absolute;
-  z-index: 1;
+  z-index: 2;
 `;
 
 function FeatureCard({
@@ -229,7 +229,11 @@ function FeatureCard({
         </div>
       </a>
       { ctaUrl && (
-        <CtaLink ctaUrl={ctaUrl}>
+        <CtaLink
+          aria-label={`${ctaText} (opens in new window)`}
+          href={ctaUrl}
+          target="_blank"
+        >
           { ctaText }
         </CtaLink>
       )}

--- a/src/components/Cards/ReviewableSummaryCard/__test__/ReviewableSummaryCard.spec.js
+++ b/src/components/Cards/ReviewableSummaryCard/__test__/ReviewableSummaryCard.spec.js
@@ -10,10 +10,11 @@ import breakpoints from '../../../../styles/breakpoints';
 const defaultProps = {
   id: 2058,
   name: 'Morton & Bassett Chili Powder',
+  isShortList: true,
   recommendationStatus: 'Recommended',
+  winnerHeader: 'Best Buy',
   testersComments: '<p>This “smoky, sizzling, full-flavored” chili powder was “much more dimensional than others.” “The flavor I’ve been waiting for!” one taster wrote. The “hot, smoky, herbaceous” powder was “balanced,” “bright,” and “lively,” with “raisiny fruitiness” and a “nice building heat.”</p>',
   winner: true,
-  winnerHeader: 'Our Winner',
   asin: 'B00AW4XQ82',
   price: '$5.19 for 1.9 oz ($2.73 per oz)',
   cloudinaryId: '12540_sil-chili-powder-morton-and-bassett-3',
@@ -51,7 +52,7 @@ describe('ReviewableSummaryCard component should', () => {
 
   it('renders the editorial sticker with proper text', () => {
     renderComponent({ ...defaultProps, winner: false });
-    expect(screen.getByText('Recommended'));
+    expect(screen.getByText('Best Buy'));
   });
 
   it('renders the image with correct alt text', () => {

--- a/src/components/Cards/ReviewableSummaryCard/index.js
+++ b/src/components/Cards/ReviewableSummaryCard/index.js
@@ -143,20 +143,11 @@ const ReviewableSummaryCard = React.memo(({
         <div>
           {(sortOfWinner || recommendationStatus) && (
             <div>
-              {sortOfWinner && (
-                <Sticker
-                  className="sticker"
-                  text={winnerHeader || 'Winner'}
-                  type="editorial"
-                />
-              )}
-              {!sortOfWinner && recommendationStatus && (
-                <Sticker
-                  className="sticker"
-                  text={recommendationStatus}
-                  type="editorial"
-                />
-              )}
+              <Sticker
+                className="sticker"
+                text={sortOfWinner ? (winnerHeader || 'Winner') : recommendationStatus}
+                type="editorial"
+              />
             </div>
           )}
           <h3>{name}</h3>

--- a/src/components/Cards/ReviewableSummaryCard/index.js
+++ b/src/components/Cards/ReviewableSummaryCard/index.js
@@ -121,6 +121,7 @@ const ReviewableSummaryCard = React.memo(({
   buyNowOverrideAffiliateName,
   cloudinaryId,
   imageAltText,
+  isShortList,
   name,
   price,
   recommendationStatus,
@@ -132,6 +133,7 @@ const ReviewableSummaryCard = React.memo(({
   if (buyNowOverrideAffiliateActive && buyNowOverrideAffiliateName) {
     buyNowIcon = buyNowOverrideAffiliateName;
   }
+  const sortOfWinner = winner || isShortList;
 
   return (
     <ReviewableSummaryItemEl
@@ -139,16 +141,16 @@ const ReviewableSummaryCard = React.memo(({
     >
       <TitleImageWrapper>
         <div>
-          {(winner || recommendationStatus) && (
+          {(sortOfWinner || recommendationStatus) && (
             <div>
-              {winner && (
+              {sortOfWinner && (
                 <Sticker
                   className="sticker"
                   text={winnerHeader || 'Winner'}
                   type="editorial"
                 />
               )}
-              {!winner && recommendationStatus && (
+              {!sortOfWinner && recommendationStatus && (
                 <Sticker
                   className="sticker"
                   text={recommendationStatus}
@@ -193,6 +195,7 @@ ReviewableSummaryCard.propTypes = {
   buyNowOverrideAffiliateName: PropTypes.string,
   cloudinaryId: PropTypes.string,
   imageAltText: PropTypes.string,
+  isShortList: PropTypes.bool,
   name: PropTypes.string.isRequired,
   price: PropTypes.string,
   recommendationStatus: PropTypes.string,
@@ -207,6 +210,7 @@ ReviewableSummaryCard.defaultProps = {
   buyNowOverrideAffiliateName: null,
   cloudinaryId: null,
   imageAltText: '',
+  isShortList: false,
   price: null,
   recommendationStatus: null,
   winnerHeader: null,


### PR DESCRIPTION
If a reviewable summary card receives `isShortList` it's supposed to considered a 'winner' 