### PR TITLE
reviewable summary card formatting fixes for long labels

### DIFF
--- a/src/components/Cards/RelatedDocumentCard/index.js
+++ b/src/components/Cards/RelatedDocumentCard/index.js
@@ -98,6 +98,11 @@ const RelatedDocumentCardTitleTheme = {
       font: ${fontSize.xl}/${lineHeight.sm} ${font.pnb};
     `}
   `,
+  atk: css`
+    span {
+      ${mixins.styledLink(color.turquoise, color.seaSalt)}
+    }
+  `,
 };
 const RelatedDocumentCardTitle = styled.h4.attrs({
   className: 'related-document-card__title',
@@ -113,9 +118,6 @@ const RelatedDocumentCardSubtitleTheme = {
       align-self: flex-start;
       display: inline-block;
     `}`,
-  atk: css`
-    ${mixins.styledLink(color.turquoise, color.seaSalt)}
-  `,
 };
 const RelatedDocumentCardSubtitle = styled.span.attrs({
   className: 'related-document-card__subtitle',
@@ -194,7 +196,7 @@ const RelatedDocumentCard = ({
           </RelatedDocumentCardAttribution>
         )}
         <RelatedDocumentCardTitle>
-          {title}
+          <span>{title}</span>
         </RelatedDocumentCardTitle>
         {subtitle && (
           <RelatedDocumentCardSubtitle>

--- a/src/components/Cards/ReviewableSummaryCard/index.js
+++ b/src/components/Cards/ReviewableSummaryCard/index.js
@@ -104,6 +104,10 @@ const TitleImageWrapper = styled.div.attrs({
 
 const TitleImageContent = styled.div`
   flex: 1 0 0;
+
+  ${breakpoint('xs', 'md')`
+    max-width: calc(100% - 10rem);
+  `}
 `;
 
 const StickerWrapper = styled.div.attrs({


### PR DESCRIPTION
* Video related card - the title should have the underline link treatment, not the subtitle
* Reviewable summary item - fix overflow issues for long text