### PR TITLE
card adjustments for reviews landing page

### DIFF
--- a/src/components/Cards/ReviewableSummaryCard/index.js
+++ b/src/components/Cards/ReviewableSummaryCard/index.js
@@ -102,7 +102,9 @@ const TitleImageWrapper = styled.div.attrs({
   `}
 `;
 
-const TitleImageContent = styled.div`
+const TitleImageContent = styled.div.attrs({
+  className: 'reviewable-title',
+})`
   flex: 1 0 0;
 
   ${breakpoint('xs', 'md')`

--- a/src/components/Carousels/CardCarousel/index.js
+++ b/src/components/Carousels/CardCarousel/index.js
@@ -8,6 +8,7 @@ import FeatureCard from '../../Cards/FeatureCard';
 import HeroCard from '../../Cards/HeroCard';
 import LinearGradient from '../../DesignTokens/LinearGradient';
 import PersonCard from '../../Cards/PersonCard';
+import ReviewableSummaryCard from '../../Cards/ReviewableSummaryCard';
 import StandardCard from '../../Cards/StandardCard';
 import TallCard from '../../Cards/TallCard';
 import { cards, spacing, withThemes } from '../../../styles';
@@ -143,6 +144,7 @@ const typeMap = {
   feature: FeatureCard,
   hero: HeroCard,
   person: PersonCard,
+  reviewable: ReviewableSummaryCard,
   standard: StandardCard,
   tall: TallCard,
 };
@@ -218,7 +220,14 @@ CardCarousel.propTypes = {
   /** Callback for rendering each carousel item */
   renderItem: PropTypes.func,
   /** Sets the carousel-item styles for a particular card style */
-  type: PropTypes.oneOf(['standard', 'feature', 'person', 'tall', 'hero']).isRequired,
+  type: PropTypes.oneOf([
+    'feature',
+    'hero',
+    'person',
+    'reviewable',
+    'standard',
+    'tall',
+  ]).isRequired,
 };
 
 CardCarousel.defaultProps = {

--- a/src/components/Carousels/DocumentListCarousel/index.js
+++ b/src/components/Carousels/DocumentListCarousel/index.js
@@ -1,7 +1,6 @@
-// import breakpoint from 'styled-components-breakpoint';
+import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
 import React from 'react';
-import breakpoint from 'styled-components-breakpoint';
 import styled, { css } from 'styled-components';
 
 import CardCarousel from '../CardCarousel';
@@ -196,7 +195,13 @@ DocumentListCarousel.propTypes = {
   /** Larger title displayed above carousel */
   title: PropTypes.string.isRequired,
   /** Sets the carousel-item styles for a particular card style */
-  type: PropTypes.oneOf(['standard', 'feature', 'person', 'tall']).isRequired,
+  type: PropTypes.oneOf([
+    'feature',
+    'person',
+    'reviewable',
+    'standard',
+    'tall',
+  ]).isRequired,
 };
 
 DocumentListCarousel.defaultProps = {


### PR DESCRIPTION
Allow `reviewable` cards in the carousels. Add a classname for help with css within espresso.