### PR TITLE
update mise -version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atk/mise-ui",
-  "version": "1.4.2-canary.b254c562.0",
+  "version": "1.5.1",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "algoliasearch": "^4.0.3",


### PR DESCRIPTION
I thought the npm integration/release code would auto update the version # and it did not. I am worried the npm install process might be "off" if the package.json doesn't match the release # on npm.  