### PR TITLE
relative messes up the detail pages

### DIFF
--- a/src/components/Cards/ReviewableSummaryCard/index.js
+++ b/src/components/Cards/ReviewableSummaryCard/index.js
@@ -66,7 +66,6 @@ const TitleImageWrapper = styled.div.attrs({
 })`
   align-items: flex-start;
   display: flex;
-  position: relative;
   width: 100%;
 
   h3 {


### PR DESCRIPTION
whatever I was trying to fix by making this position relative really messed up the cards on the detail page. Will re-assess the bug from the landing page with a change in espresso.