### PR TITLE
adding cta-link classname for tracking

### DIFF
--- a/src/components/Cards/FeatureCard/index.js
+++ b/src/components/Cards/FeatureCard/index.js
@@ -239,6 +239,7 @@ function FeatureCard({
       {ctaUrl && (
         <CtaLink
           aria-label={`${ctaText} (opens in new window)`}
+          className="cta-link"
           href={ctaUrl}
           target="_blank"
         >


### PR DESCRIPTION
Reviews index page needs a `className="cta-link"` for tracking