### PR TITLE
accessibility updates for browse reviews page, specifically related to refinement list

### DIFF
--- a/src/components/Algolia/shared/AccordionRefinementList/index.js
+++ b/src/components/Algolia/shared/AccordionRefinementList/index.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connectRefinementList } from 'react-instantsearch-dom';
+
+import RefinementList2 from '../RefinementList2';
+import Accordion from '../../../Accordion';
+
+const AccordionRefinementList = ({
+  attribute,
+  icon,
+  iconSize,
+  initialCount,
+  items,
+  showHideLabel,
+  ...restProps
+}) => (
+  items && items.length > 0 ? (
+    <Accordion
+      icon={icon}
+      iconSize={iconSize}
+      label={() => <h3 className="accordion-ref-list__heading">{showHideLabel}</h3>}
+    >
+      <RefinementList2
+        attribute={attribute}
+        initialCount={initialCount}
+        items={items}
+        {...restProps}
+      />
+    </Accordion>
+  ) : null
+);
+
+AccordionRefinementList.propTypes = {
+  /** Algolia attribute that is used to pull refinement values. */
+  attribute: PropTypes.string.isRequired,
+  /* Name of icon */
+  icon: PropTypes.string,
+  /* Size of icon */
+  iconSize: PropTypes.oneOf(['default', 'large']),
+  /** Number of menu items to show by default */
+  initialCount: PropTypes.number,
+  /** Refinement filter values from algolia */
+  items: PropTypes.array.isRequired,
+  /** Used to pass click functionality from jarvis etc. */
+  handleClick: PropTypes.func,
+  /** 'Title' of the list that will be put into clickable show/hide button */
+  showHideLabel: PropTypes.string.isRequired,
+  /** Initial number of refinement filters that are visible in the refinement list. */
+  transformItems: PropTypes.func,
+};
+
+AccordionRefinementList.defaultProps = {
+  handleClick: null,
+  icon: null,
+  iconSize: 'default',
+  initialCount: 3,
+  transformItems: null,
+};
+
+export default connectRefinementList(AccordionRefinementList);

--- a/src/components/Algolia/shared/RefinementFilter2/RefinementFilter2.stories.js
+++ b/src/components/Algolia/shared/RefinementFilter2/RefinementFilter2.stories.js
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import LabelFrame from '../../../LabelFrame';
+import RefinementFilter2 from './index';
+
+export default {
+  title: 'Components|Algolia/shared/RefinementFilter2',
+  component: RefinementFilter2,
+};
+
+export const UncheckedWithoutCount = () => (
+  <LabelFrame label="Component">
+    <RefinementFilter2
+      attribute="search_review_type_list"
+      label="Equipment Reviews"
+      value="equipment_reviews"
+    />
+  </LabelFrame>
+);
+
+export const UncheckedWithCount = () => (
+  <LabelFrame label="Component">
+    <RefinementFilter2
+      attribute="search_review_type_list"
+      count="444"
+      includeCount
+      label="Equipment Reviews"
+      value="equipment_reviews"
+    />
+  </LabelFrame>
+);
+
+export const CheckedWithoutCount = () => (
+  <LabelFrame label="Component">
+    <RefinementFilter2
+      attribute="search_review_type_list"
+      isRefined
+      label="Equipment Reviews"
+      value="equipment_reviews"
+    />
+  </LabelFrame>
+);
+
+export const CheckedWithCount = () => (
+  <LabelFrame label="Component">
+    <RefinementFilter2
+      attribute="search_review_type_list"
+      count="444"
+      includeCount
+      isRefined
+      label="Equipment Reviews"
+      value="equipment_reviews"
+    />
+  </LabelFrame>
+);

--- a/src/components/Algolia/shared/RefinementFilter2/index.js
+++ b/src/components/Algolia/shared/RefinementFilter2/index.js
@@ -1,0 +1,165 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+
+import { Checkmark } from '../../../DesignTokens/Icon/svgs';
+import { color, font, fontSize, spacing, withThemes } from '../../../../styles';
+
+const RefinementFilterWrapper = styled.div`
+  align-items: center;
+  display: flex;
+
+  &:focus-within {
+    box-shadow: 0 0 0 2px ${color.focusRing};
+  }
+
+  &:hover {
+    cursor: pointer;
+
+    .search-refinement-list__label {
+      color: ${color.mint};
+    }
+  }
+`;
+
+const RefinementFilterLabelTheme = {
+  default: css`
+    color: ${color.eclipse};
+    font: ${fontSize.md}/1.38 ${font.pnr};
+
+    &:hover {
+      color: ${color.mint};
+      cursor: pointer;
+    }
+
+    ${({ isRefined }) => (isRefined ? `color: ${color.mint}; font: ${fontSize.md}/1.38 ${font.pnb};` : '')}
+  `,
+};
+
+const RefinementFilterLabel = styled.label.attrs({
+  className: 'search-refinement-list__label',
+})`${withThemes(RefinementFilterLabelTheme)}`;
+
+const RefinementFilterCountTheme = {
+  default: css`
+    color: ${color.nobel};
+  `,
+  dark: css`
+    color: ${color.white};
+  `,
+};
+
+const RefinementFilterCount = styled.span.attrs({
+  className: 'refinement-filter__count',
+})`${withThemes(RefinementFilterCountTheme)}`;
+
+const RefinementFilterCheckTheme = {
+  default: css`
+    height: 1.2rem;
+    margin-left: -2rem;
+    margin-right: ${spacing.xsm};
+    position: relative;
+    width: 1.2rem;
+
+    svg {
+      left: 0;
+      position: absolute;
+      top: 0;
+    }
+  `,
+  dark: css`
+    svg {
+      path {
+        fill: ${color.white};
+      }
+    }
+  `,
+};
+
+const RefinementFilterCheck = styled.div.attrs({
+  className: 'refinement-filter__checkmark',
+})`${withThemes(RefinementFilterCheckTheme)}`;
+
+const RefinementFilterCheckbox = styled.input`
+  height: 0.8rem;
+  left: -2rem;
+  position: absolute;
+  opacity: 0;
+  width: 1.2rem;
+`;
+
+const RefinementFilter = ({
+  attribute,
+  count,
+  currentRefinement,
+  filterType,
+  handleClick,
+  includeCount,
+  isRefined,
+  label,
+  refine,
+  value,
+}) => (
+  <RefinementFilterWrapper
+    onClick={(e) => {
+      e.preventDefault();
+      if (!isRefined && typeof handleClick === 'function') handleClick(e);
+      if (filterType === 'refinementList') {
+        refine(value);
+      } else if (filterType === 'toggleRefinement') {
+        if (currentRefinement.length > 0) {
+          refine(false);
+        } else {
+          refine(value);
+        }
+      }
+    }}
+  >
+    {
+      isRefined || (filterType === 'toggleRefinement' && currentRefinement.length > 0) ? (
+        <RefinementFilterCheck data-testid="refinement-filter__checkmark">
+          <Checkmark />
+        </RefinementFilterCheck>
+      ) : null
+    }
+    <RefinementFilterCheckbox defaultChecked={isRefined} id={`${attribute}-${value}-filter`} type="checkbox" />
+    <RefinementFilterLabel
+      htmlFor={`${attribute}-${value}-filter`}
+      isRefined={isRefined}
+    >
+      {label}{includeCount && count ? <RefinementFilterCount>{` (${count})`}</RefinementFilterCount> : null}
+    </RefinementFilterLabel>
+  </RefinementFilterWrapper>
+);
+
+RefinementFilter.propTypes = {
+  /** Algolia attribute used to filter results. */
+  attribute: PropTypes.string,
+  /** Number of hits for this filter value. */
+  count: PropTypes.number,
+  currentRefinement: PropTypes.bool,
+  filterType: PropTypes.string,
+  includeCount: PropTypes.bool,
+  /** Is this filter selected? */
+  isRefined: PropTypes.bool,
+  /** Filter label */
+  label: PropTypes.string.isRequired,
+  /** Call this with the value of a filter to refine results based on filter. */
+  refine: PropTypes.func.isRequired,
+  /** Used to pass click functionality from jarvis etc. */
+  handleClick: PropTypes.func,
+  /** Value of filter to be used for refining results. */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.array], PropTypes.string).isRequired,
+};
+
+RefinementFilter.defaultProps = {
+  attribute: '',
+  count: null,
+  currentRefinement: null,
+  filterType: 'refinementList',
+  includeCount: true,
+  isRefined: null,
+  handleClick: null,
+};
+
+export default RefinementFilter;

--- a/src/components/Algolia/shared/RefinementList2/RefinementList2.stories.js
+++ b/src/components/Algolia/shared/RefinementList2/RefinementList2.stories.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import LabelFrame from '../../../LabelFrame';
+import MiseInstantSearch from '../../../../lib/algolia/MiseInstantSearch/MiseInstantSearch';
+import RefinementList2 from './index';
+
+export default {
+  title: 'Components|Algolia/shared/RefinementList2',
+  component: RefinementList2,
+};
+
+export const WithLabelIcon = () => (
+  <MiseInstantSearch>
+    <LabelFrame label="Component">
+      <RefinementList2
+        attribute="search_cookbook_collection_titles"
+        legend="Cookbook Collection"
+        operator="and"
+        showHideLabel="COOKBOOK COLLECTION"
+      />
+    </LabelFrame>
+  </MiseInstantSearch>
+);

--- a/src/components/Algolia/shared/RefinementList2/index.js
+++ b/src/components/Algolia/shared/RefinementList2/index.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ShowMoreLess from '../../../ShowMoreLess';
+import RefinementFilter2 from '../RefinementFilter2';
+
+export const CustomRefinementList = ({
+  attribute,
+  hideLegend,
+  initialCount,
+  items,
+  legend,
+  refine,
+  handleClick,
+}) => (
+  <fieldset>
+    <legend className={hideLegend ? 'visuallyhidden' : null}>{legend}</legend>
+    <ShowMoreLess
+      id={`show-more-less--${attribute}`}
+      initialCount={initialCount}
+      items={
+        items.map(item => (
+          <RefinementFilter2
+            {...item}
+            attribute={attribute}
+            key={`${attribute}-${item.label}`}
+            handleClick={handleClick}
+            refine={refine}
+          />
+        ))
+      }
+    />
+  </fieldset>
+);
+
+CustomRefinementList.propTypes = {
+  attribute: PropTypes.string.isRequired,
+  currentRefinement: PropTypes.array.isRequired,
+  handleClick: PropTypes.func,
+  hideLegend: PropTypes.bool.isRequired,
+  /** Number of menu items to show by default */
+  initialCount: PropTypes.number,
+  items: PropTypes.array,
+  legend: PropTypes.string.isRequired,
+  refine: PropTypes.func.isRequired,
+};
+
+CustomRefinementList.defaultProps = {
+  handleClick: null,
+  initialCount: 3,
+  items: null,
+};
+
+const RefinementList2 = ({ attribute, items, ...restProps }) => (
+  items && items.length > 0 ? (
+    <CustomRefinementList
+      attribute={attribute}
+      items={items}
+      {...restProps}
+    />
+  ) : null
+);
+
+RefinementList2.propTypes = {
+  /** Algolia attribute that is used to pull refinement values. */
+  attribute: PropTypes.string.isRequired,
+  /** Algolia attribute, list of refinement values. */
+  items: PropTypes.array.isRequired,
+  /** Used to pass click functionality from jarvis etc. */
+  handleClick: PropTypes.func,
+  /** Visually hides legend, but keeps it accessible for screen reader users */
+  hideLegend: PropTypes.bool,
+  /** Used to label fieldset for accessibility */
+  legend: PropTypes.string.isRequired,
+  /** Initial number of refinement filters that are visible in the refinement list. */
+  transformItems: PropTypes.func,
+};
+
+RefinementList2.defaultProps = {
+  handleClick: null,
+  hideLegend: true,
+  transformItems: null,
+};
+
+export default RefinementList2;

--- a/src/components/Algolia/shared/ToggleRefinement/index.js
+++ b/src/components/Algolia/shared/ToggleRefinement/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connectRefinementList } from 'react-instantsearch-dom';
 
-import RefinementFilter from '../RefinementFilter/RefinementFilter';
+import RefinementFilter2 from '../RefinementFilter2';
 
 const ToggleRefinement = ({
   attribute,
@@ -11,7 +11,7 @@ const ToggleRefinement = ({
   ...restProps
 }) => (
   <div className="toggle-refinement">
-    <RefinementFilter
+    <RefinementFilter2
       attribute={attribute}
       filterType="toggleRefinement"
       includeCount={false}

--- a/src/components/Cards/shared/Title/index.js
+++ b/src/components/Cards/shared/Title/index.js
@@ -22,7 +22,7 @@ const TitleTheme = {
     }
   `,
 };
-const StyledTitle = styled.h3`
+const StyledTitle = styled.p`
   ${withThemes(TitleTheme)};
 `;
 

--- a/src/components/FilterButton/index.js
+++ b/src/components/FilterButton/index.js
@@ -48,9 +48,13 @@ const StyledFilter = styled(Filter)`
   ${withThemes(StyledFilterTheme)}
 `;
 
-const FilterButton = ({ className, onClick, text }) => (
+const FilterButton = ({ ariaControls, ariaExpanded, ariaLabel, className, id, onClick, text }) => (
   <StyledFilterButton
+    aria-controls={ariaControls}
+    aria-expanded={ariaExpanded}
+    aria-label={ariaLabel}
     className={className}
+    id={id}
     onClick={onClick}
   >
     {text}
@@ -59,13 +63,21 @@ const FilterButton = ({ className, onClick, text }) => (
 );
 
 FilterButton.propTypes = {
+  ariaControls: PropTypes.string,
+  ariaExpanded: PropTypes.bool,
+  ariaLabel: PropTypes.string,
   className: PropTypes.string,
+  id: PropTypes.string,
   onClick: PropTypes.func,
   text: PropTypes.string,
 };
 
 FilterButton.defaultProps = {
+  ariaControls: null,
+  ariaExpanded: null,
+  ariaLabel: null,
   className: null,
+  id: null,
   onClick: null,
   text: 'Filter',
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import * as styles from './styles';
 import AudioPlayer from './components/AudioPlayer';
 import Accordion from './components/Accordion';
 import AccordionControl from './components/AccordionControl';
+import AccordionRefinementList from './components/Algolia/shared/AccordionRefinementList';
 import Badge from './components/Badge';
 import breakpoints from './styles/breakpoints';
 import Brands from './components/DesignTokens/Brands';
@@ -69,6 +70,7 @@ import { color, mixins, spacing } from './styles';
 export {
   Accordion,
   AccordionControl,
+  AccordionRefinementList,
   AudioPlayer,
   Badge,
   breakpoints,


### PR DESCRIPTION
While working on the accessibility QA card for the browse reviews page I ran into a ton of issues with `RefinementList` and `RefinementFilter` related to accessibility. Navigating through the filters with a screen reader made almost no sense. The readouts with these new components are much clearer.

I created two new temporary components (great names right?):
* `RefinementFilter2`
* `RefinementList2`

I also created a new wrapper for these components, `AccordionRefinementList`, which behaves similarly to the existing `SearchRefinementList` component.

These components are based off of the existing components, but built with a better foundation for accessibility. I did not want to edit the existing components as there are many pages across multiple brands tied to those components and it would have caused too much overhead. Moving forward as we have time, we can move each of those old pages over to these new refinement components.

Espesso implementation PR will follow.