### PR TITLE
provide sizes on image tag, reduce image size

### DIFF
--- a/src/components/Cards/CategoryCard/index.js
+++ b/src/components/Cards/CategoryCard/index.js
@@ -113,6 +113,7 @@ const CategoryCard = ({
             <Image
               className="category-product-image"
               height={60}
+              imageAlt=""
               imageUrl={getImageUrl(cloudinaryId, 'thumbnail', { size: 'small' })}
               lazy={lazy}
               width={60}

--- a/src/components/Cards/CategoryCard/index.js
+++ b/src/components/Cards/CategoryCard/index.js
@@ -112,8 +112,10 @@ const CategoryCard = ({
           {assetType === 'productImage' ? (
             <Image
               className="category-product-image"
-              imageUrl={getImageUrl(cloudinaryId)}
+              height={60}
+              imageUrl={getImageUrl(cloudinaryId, 'thumbnail', { size: 'small' })}
               lazy={lazy}
+              width={60}
             />
           ) : (
             <SvgWrapper>

--- a/src/components/Cards/FeatureCard/index.js
+++ b/src/components/Cards/FeatureCard/index.js
@@ -145,6 +145,7 @@ function FeatureCard({
   attributions,
   className,
   contentType,
+  ctaDataAttrs,
   ctaText,
   ctaUrl,
   dataAttrs,
@@ -242,6 +243,7 @@ function FeatureCard({
           className="cta-link"
           href={ctaUrl}
           target="_blank"
+          {...ctaDataAttrs}
         >
           {ctaText}
         </CtaLink>
@@ -254,6 +256,7 @@ FeatureCard.propTypes = {
   attributions: PropTypes.string,
   className: PropTypes.string,
   contentType: PropTypes.string.isRequired,
+  ctaDataAttrs: PropTypes.object,
   ctaText: PropTypes.string,
   ctaUrl: PropTypes.string,
   /** document data attributes */
@@ -283,6 +286,7 @@ FeatureCard.propTypes = {
 FeatureCard.defaultProps = {
   attributions: '',
   className: '',
+  ctaDataAttrs: null,
   ctaText: '',
   ctaUrl: '',
   dataAttrs: null,

--- a/src/components/Cards/ReviewableSummaryCard/index.js
+++ b/src/components/Cards/ReviewableSummaryCard/index.js
@@ -255,7 +255,7 @@ const ReviewableSummaryCard = React.memo(({
               dataAttrs={{
                 'data-asin': asin || '',
                 'data-price': price || '',
-                'data-recommendation-status': stickerText,
+                'data-recommendation-status': recommendationStatus,
                 'data-reviewable': name,
               }}
               text={displayPrice && price ? `Buy for ${price}` : 'Buy Now'}

--- a/src/components/Cards/shared/Image/index.js
+++ b/src/components/Cards/shared/Image/index.js
@@ -13,10 +13,12 @@ const inlineSrc = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAA
 
 const Image = ({
   className,
+  height,
   imageAlt,
   imageUrl,
   lazy,
   lowQualityImageUrl,
+  width,
 }) => {
   const intersectionRef = useRef(null);
   const isPrint = useMedia('print');
@@ -61,24 +63,36 @@ const Image = ({
     <StyledImage
       alt={imageAlt}
       className={className}
+      height={height}
       ref={intersectionRef}
       src={src}
+      width={width}
     />
   );
 };
 
 Image.propTypes = {
   className: PropTypes.string,
+  height: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
   imageAlt: PropTypes.string.isRequired,
   imageUrl: PropTypes.string.isRequired,
   lazy: PropTypes.bool,
   lowQualityImageUrl: PropTypes.string,
+  width: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
 };
 
 Image.defaultProps = {
   className: '',
+  height: null,
   lazy: true,
   lowQualityImageUrl: null,
+  width: null,
 };
 
 export default Image;


### PR DESCRIPTION
* Page speed feedback is complaining about all of these images not having a size. Since they're all confined to a consistent size, adding the width/height attributes is fine
* Reduce the size of the images to small thumbs from large thumbs