### PR TITLE
ARCHIE-2321: create ArticleImage component for Articles

### DIFF
--- a/src/components/Articles/ArticleImage/ArticleImage.stories.js
+++ b/src/components/Articles/ArticleImage/ArticleImage.stories.js
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import ArticleImage from './index';
+
+export default {
+  title: 'Components|Articles/ArticleImage',
+  component: ArticleImage,
+};
+
+const alt = 'A chef is holding a pan with garlic bread on it.';
+const caption = 'The heat applied during pasteurization, a necessary step for all shelf-stable jars, essentially cooks the pickles.';
+const imgSrcs = {
+  desktopSrc: 'https://res.cloudinary.com/hksqkdlah/image/upload/c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_632/v1/AKO%20Articles/2021%20Articles/Reviews%20Team/GettyImages-680787007',
+  imgSrc: 'https://res.cloudinary.com/hksqkdlah/image/upload/c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_341/v1/AKO%20Articles/2021%20Articles/Reviews%20Team/GettyImages-680787007',
+  tabletSrc: 'https://res.cloudinary.com/hksqkdlah/image/upload/c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_697/v1/AKO%20Articles/2021%20Articles/Reviews%20Team/GettyImages-680787007',
+};
+
+export const DefaultWithCaption = () => (
+  <ArticleImage
+    {...imgSrcs}
+    alt={alt}
+    caption={caption}
+  />
+);
+
+export const DefaultWithoutCaption = () => (
+  <ArticleImage
+    {...imgSrcs}
+    alt={alt}
+  />
+);
+
+export const WideWithCaption = () => (
+  <ArticleImage
+    {...imgSrcs}
+    alt={alt}
+    caption={caption}
+    width="wide"
+  />
+);
+
+export const WideWithoutCaption = () => (
+  <ArticleImage
+    {...imgSrcs}
+    alt={alt}
+    width="wide"
+  />
+);

--- a/src/components/Articles/ArticleImage/__test__/ArticleImage.spec.js
+++ b/src/components/Articles/ArticleImage/__test__/ArticleImage.spec.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import 'jest-styled-components';
+
+import ArticleImage from '../index';
+import breakpoints from '../../../../styles/breakpoints';
+
+describe('ArticleImage component should', () => {
+  const renderComponent = props => (
+    render(
+      <ThemeProvider theme={{ breakpoints }}>
+        <ArticleImage
+          {...props}
+          alt="Test Alt Text"
+          imgSrc="https://res.cloudinary.com/hksqkdlah/image/upload/c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_341/v1/AKO%20Articles/2021%20Articles/Reviews%20Team/GettyImages-680787007"
+        />
+      </ThemeProvider>,
+    )
+  );
+
+  it('render an image', () => {
+    renderComponent({});
+    expect(screen.getByAltText('Test Alt Text'));
+  });
+
+  it('render a caption if provided', () => {
+    renderComponent({ caption: 'Test Caption' });
+    expect(screen.getByText('Test Caption'));
+  });
+
+  it('not render a caption if not provided', () => {
+    renderComponent({});
+    expect(!screen.queryByText('Test Caption'));
+  });
+});

--- a/src/components/Articles/ArticleImage/index.js
+++ b/src/components/Articles/ArticleImage/index.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import breakpoint from 'styled-components-breakpoint';
+
+import ArticleFigcaption from '../shared/ArticleFigcaption';
+import { mixins } from '../../../styles';
+
+const ArticleImageFigure = styled.figure`
+  padding: 0;
+  margin: 0 0 2.8rem;
+
+  ${breakpoint('xs', 'xlg')`
+    .article-figcaption {
+      padding-bottom: 1.2rem;
+    }
+  `}
+
+  ${breakpoint('xlg')`
+    display: flex;
+
+    .article-figcaption {
+      max-width: 20rem;
+      width: 100%;
+    }
+
+    &.article-image__figure--wide {
+      flex-direction: column;
+
+      .article-figcaption {
+        max-width: 63.4rem;
+        width: 100%;
+      }
+    }
+  `}
+`;
+
+const ArticleImagePicture = styled.picture`
+  img {
+    display: block;
+    margin-bottom: 1.2rem;
+
+    ${breakpoint('xlg')`
+      margin-right: 1.6rem;
+      ${mixins.articlesWidth('default')}
+    `}
+  }
+
+  &.article-image__picture--wide {
+    img {
+      margin-right: 0;
+      ${mixins.articlesWidth('wide')}
+    }
+  }
+`;
+
+const ArticleImage = ({ alt, caption, desktopSrc, imgSrc, tabletSrc, width }) => (
+  <ArticleImageFigure className={`article-image__figure--${width}`}>
+    <ArticleImagePicture className={`article-image__picture--${width}`}>
+      {
+        desktopSrc && (
+          <source
+            media="(min-width: 1136px)"
+            srcSet={desktopSrc}
+          />
+        )
+      }
+      {
+        tabletSrc && (
+          <source
+            media="(min-width: 768px)"
+            srcSet={tabletSrc}
+          />
+        )
+      }
+      <img
+        alt={alt}
+        src={imgSrc}
+      />
+    </ArticleImagePicture>
+    {
+      caption && (
+        <ArticleFigcaption
+          caption={caption}
+          decorationPosition={width === 'default' ? 'top' : 'bottom'}
+        />
+      )
+    }
+  </ArticleImageFigure>
+);
+
+ArticleImage.propTypes = {
+  /** Alt text for image. */
+  alt: PropTypes.string,
+  /** Editorial caption for image */
+  caption: PropTypes.string,
+  /** Desktop sized image source */
+  desktopSrc: PropTypes.string,
+  /** Default image source */
+  imgSrc: PropTypes.string.isRequired,
+  /** Tablet sized image source */
+  tabletSrc: PropTypes.string,
+  /** Width configuration for PullQuote */
+  width: PropTypes.oneOf(['default', 'wide']),
+};
+
+ArticleImage.defaultProps = {
+  alt: '',
+  caption: null,
+  desktopSrc: null,
+  tabletSrc: null,
+  width: 'default',
+};
+
+export default ArticleImage;

--- a/src/components/Articles/PullQuote/__tests__/PullQuote.spec.js
+++ b/src/components/Articles/PullQuote/__tests__/PullQuote.spec.js
@@ -33,11 +33,11 @@ describe('PullQuote component should', () => {
 
   it('render an attribution when provided', () => {
     renderComponent({ quote: 'Test Quote', attribution: 'Test Citation' });
-    expect(screen.getByTestId('pull-quote__attribution') && screen.queryByText('Test Citatioin'));
+    expect(screen.queryByText('Test Citation'));
   });
 
   it('not render an attribution when not provided', () => {
     renderComponent({ quote: 'Test Quote' });
-    expect(!screen.queryByTestId('pull-quote__attribution') && !screen.queryByText('Test Citation'));
+    expect(!screen.queryByText('Test Citation'));
   });
 });

--- a/src/components/Articles/PullQuote/index.js
+++ b/src/components/Articles/PullQuote/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 
+import ArticleFigcaption from '../shared/ArticleFigcaption';
 import { Quote } from '../../DesignTokens/Icon/svgs';
 import { color, font, fontSize, mixins } from '../../../styles';
 
@@ -40,6 +41,12 @@ const PullQuoteIcon = styled.div`
 const PullQuoteFigure = styled.figure`
   margin: 0;
   padding: 0;
+
+  ${breakpoint('xlg')`
+    .article-figcaption {
+      padding-bottom: 0.8rem;
+    }
+  `}
 `;
 
 const PullQuoteBlockQuote = styled.blockquote`
@@ -49,22 +56,6 @@ const PullQuoteBlockQuote = styled.blockquote`
   font-weight: bold;
   margin: 0 0 1.2rem 0;
   padding: 0;
-`;
-
-const PullQuoteFigcaption = styled.figcaption`
-  color: ${color.mediumGray};
-  font: ${fontSize.md}/1.5 ${font.pnb};
-  position: relative;
-
-  &::after {
-    bottom: -0.8rem;
-    background-color: ${color.mint};
-    content: '';
-    display: block;
-    height: 0.6rem;
-    position: absolute;
-    width: 1.6rem;
-  }
 `;
 
 const PullQuote = ({ attribution, includeIcon, quote, width }) => (
@@ -82,9 +73,10 @@ const PullQuote = ({ attribution, includeIcon, quote, width }) => (
       </PullQuoteBlockQuote>
       {
         attribution && (
-          <PullQuoteFigcaption data-testid="pull-quote__attribution">
-            {attribution}
-          </PullQuoteFigcaption>
+          <ArticleFigcaption
+            caption={attribution}
+            decorationPosition="bottom"
+          />
         )
       }
     </PullQuoteFigure>

--- a/src/components/Articles/shared/ArticleFigcaption/ArticleFigcaption.stories.js
+++ b/src/components/Articles/shared/ArticleFigcaption/ArticleFigcaption.stories.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import ArticleFigcaption from './index';
+
+export default {
+  title: 'Components|Articles/shared/ArticleFigcaption',
+  component: ArticleFigcaption,
+};
+
+const caption = 'The heat applied during pasteurization, a necessary step for all shelf-stable jars, essentially cooks the pickles.';
+
+export const DecorationOnTop = () => (
+  <ArticleFigcaption
+    caption={caption}
+    decorationPosition="top"
+  />
+);
+
+export const DecorationOnBottom = () => (
+  <ArticleFigcaption
+    caption={caption}
+    decorationPosition="bottom"
+  />
+);

--- a/src/components/Articles/shared/ArticleFigcaption/__tests__/Figcaption.spec.js
+++ b/src/components/Articles/shared/ArticleFigcaption/__tests__/Figcaption.spec.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import 'jest-styled-components';
+
+import ArticleFigcaption from '../index';
+import breakpoints from '../../../../../styles/breakpoints';
+
+describe('ArticleFigcaption component should', () => {
+  const renderComponent = props => (
+    render(
+      <ThemeProvider theme={{ breakpoints }}>
+        <ArticleFigcaption {...props} />
+      </ThemeProvider>,
+    )
+  );
+
+  it('render caption text', () => {
+    const caption = 'Test Caption';
+    renderComponent({ caption, decorationPosition: 'bottom' });
+    expect(screen.getByText(caption));
+  });
+});

--- a/src/components/Articles/shared/ArticleFigcaption/index.js
+++ b/src/components/Articles/shared/ArticleFigcaption/index.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import breakpoint from 'styled-components-breakpoint';
+
+import { color, font, fontSize } from '../../../../styles';
+
+const ArticleFigcaptionWrapper = styled.figcaption`
+  color: ${color.mediumGray};
+  font: ${fontSize.md}/1.5 ${font.pnb};
+  position: relative;
+
+  ${breakpoint('xs', 'xlg')`
+    padding-bottom: 0.8rem;
+  `}
+
+  ${breakpoint('xlg')`
+    ${({ decorationPosition }) => (decorationPosition === 'bottom' ? 'padding-bottom: 0.8rem;' : 'padding-top: 0.8rem;')}
+  `}
+
+  &::after {
+    background-color: ${color.mint};
+    content: '';
+    display: block;
+    height: 0.6rem;
+    position: absolute;
+    width: 1.6rem;
+
+    ${breakpoint('xs', 'xlg')`
+      bottom: 0;
+    `}
+
+    ${breakpoint('xlg')`
+      ${({ decorationPosition }) => (decorationPosition === 'bottom' ? 'bottom: 0;' : 'top: 0;')}
+    `}
+  }
+`;
+
+const ArticleFigcaption = ({ caption, decorationPosition }) => (
+  <ArticleFigcaptionWrapper
+    className="article-figcaption"
+    decorationPosition={decorationPosition}
+  >
+    {caption}
+  </ArticleFigcaptionWrapper>
+);
+
+ArticleFigcaption.propTypes = {
+  /** Caption text */
+  caption: PropTypes.string.isRequired,
+  /** Postion style decoration above or below caption (Only applies to desktop) */
+  decorationPosition: PropTypes.oneOf(['bottom', 'top']).isRequired,
+};
+
+export default ArticleFigcaption;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import AudioPlayer from './components/AudioPlayer';
 import Accordion from './components/Accordion';
 import AccordionControl from './components/AccordionControl';
 import AccordionRefinementList from './components/Algolia/shared/AccordionRefinementList';
+import ArticleImage from './components/Articles/ArticleImage';
 import Badge from './components/Badge';
 import breakpoints from './styles/breakpoints';
 import Brands from './components/DesignTokens/Brands';
@@ -72,6 +73,7 @@ export {
   Accordion,
   AccordionControl,
   AccordionRefinementList,
+  ArticleImage,
   AudioPlayer,
   Badge,
   breakpoints,


### PR DESCRIPTION
I also pulled the styled figcaption out of `PullQuote` and made it into the reusable `ArticleFigcaption` this is used for `PullQuote`, `ArticleImage` and will be used for other image components for this project.