### PR TITLE
minor update to data parsing in ArticlePhotoCollection to support api structure

### DIFF
--- a/src/components/Articles/ArticlePhotoCollection/ArticlePhotoCollection.stories.js
+++ b/src/components/Articles/ArticlePhotoCollection/ArticlePhotoCollection.stories.js
@@ -9,37 +9,37 @@ export default {
 };
 
 export const defaultTwoImages = () => (
-  <ArticlePhotoCollection 
+  <ArticlePhotoCollection
     caption={"The heat applied during pasteurization, a necessary step for all shelf-stable jars, essentially cooks the pickles. Pickle spears (left) are especially vulnerable and often turn out soft and soggy. Shelf-stable whole pickles (right) are much more likely to stay firm and crunchy."}
     count={2}
-    items={images.slice(0, 2)}
+    images={images.slice(0, 2)}
     title=""
     width="default"
   />
 );
 
 export const defaultThreeImagesWithTitle = () => (
-    <ArticlePhotoCollection 
+    <ArticlePhotoCollection
     caption={"The heat applied during pasteurization, a necessary step for all shelf-stable jars, essentially cooks the pickles. Pickle spears (left) are especially vulnerable and often turn out soft and soggy. Shelf-stable whole pickles (right) are much more likely to stay firm and crunchy."}
     count={3}
-    items={images}
+    images={images}
     title="Collection of Pickle Photos"
     width="default"
   />
 );
 
 export const wideTwoImagesWithTitle = () => (
-    <ArticlePhotoCollection 
+    <ArticlePhotoCollection
     caption={"The heat applied during pasteurization, a necessary step for all shelf-stable jars, essentially cooks the pickles. Pickle spears (left) are especially vulnerable and often turn out soft and soggy. Shelf-stable whole pickles (right) are much more likely to stay firm and crunchy."}
     count={2}
-    items={images.slice(0, 2)}
+    images={images.slice(0, 2)}
     title="Collection of Pickle Photos"
     width="wide"
   />
 );
 
 export const wideThreeImages = () => (
-    <ArticlePhotoCollection 
+    <ArticlePhotoCollection
     caption={"The heat applied during pasteurization, a necessary step for all shelf-stable jars, essentially cooks the pickles. Pickle spears (left) are especially vulnerable and often turn out soft and soggy. Shelf-stable whole pickles (right) are much more likely to stay firm and crunchy."}
     count={3}
     items={images}

--- a/src/components/Articles/ArticlePhotoCollection/__tests__/ArticlePhotoCollection.spec.js
+++ b/src/components/Articles/ArticlePhotoCollection/__tests__/ArticlePhotoCollection.spec.js
@@ -20,19 +20,19 @@ describe('ArticlePhotoCollection component should', () => {
   );
 
   it('renders optional title', () => {
-    renderComponent({ title: 'Testing title', count: 3, items: images, width: 'wide' });
+    renderComponent({ title: 'Testing title', count: 3, images, width: 'wide' });
     expect(screen.getByText('Testing title'));
   });
 
   it('renders optional caption', () => {
-    renderComponent({ caption: 'testing caption', count: 3, items: images, width: 'wide' });
+    renderComponent({ caption: 'testing caption', count: 3, images, width: 'wide' });
     expect(screen.getByText('testing caption'));
   });
 
   it('renders multiple images to size--two, default', () => {
     renderComponent({
       count: 2,
-      items: images.slice(0, 2),
+      images: images.slice(0, 2),
       width: 'default',
     });
     const renderedImages = document.getElementsByTagName('picture');
@@ -43,7 +43,7 @@ describe('ArticlePhotoCollection component should', () => {
   it('renders multiple images to size--three, wide', () => {
     renderComponent({
       count: 3,
-      items: images,
+      images,
       width: 'wide',
     });
     const renderedImages = document.getElementsByTagName('picture');

--- a/src/components/Articles/ArticlePhotoCollection/imagesResponse.js
+++ b/src/components/Articles/ArticlePhotoCollection/imagesResponse.js
@@ -1,36 +1,25 @@
-const images = [{
-  type: 'Photo',
-  attributes: {
-    photo: {
-      publicId: 'TnT/2020/1_CCJJ_Dill%20Pickles/STP_Spear_Crunch_102',
-      contentWidth: 400,
-      height: 400,
-      format: 'gif',
-    },
+const images = [
+  {
+    publicId: 'TnT/2020/1_CCJJ_Dill%20Pickles/STP_Spear_Crunch_102',
+    width: 400,
+    height: 400,
+    format: 'gif',
     altText: '4picture of a thing',
   },
-}, {
-  type: 'Photo',
-  attributes: {
-    photo: {
-      publicId: 'TnT/2020/1_CCJJ_Dill%20Pickles/STP_Spear_Crunch_102',
-      contentWidth: 400,
-      height: 400,
-      format: 'gif',
-    },
+  {
+    publicId: 'TnT/2020/1_CCJJ_Dill%20Pickles/STP_Spear_Crunch_102',
+    width: 400,
+    height: 400,
+    format: 'gif',
     altText: '5picture of a thing',
   },
-}, {
-  type: 'Photo',
-  attributes: {
-    photo: {
-      publicId: 'TnT/2020/1_CCJJ_Dill%20Pickles/STP_Spear_Crunch_102',
-      contentWidth: 400,
-      height: 400,
-      format: 'gif',
-    },
+  {
+    publicId: 'TnT/2020/1_CCJJ_Dill%20Pickles/STP_Spear_Crunch_102',
+    width: 400,
+    height: 400,
+    format: 'gif',
     altText: '6picture of a thing',
   },
-}];
+];
 
 export default images;

--- a/src/components/Articles/ArticlePhotoCollection/index.js
+++ b/src/components/Articles/ArticlePhotoCollection/index.js
@@ -88,7 +88,7 @@ const CollectionPicture = styled.picture`
   ${breakpoint('xlg')`
     .photo-two-up {
       ${({ width }) => mixins.articlesTwoUpImageCollection(width)}
-    }  
+    }
 
     .photo-three-up {
       ${({ width }) => mixins.articlesThreeUpImageCollection(width)}
@@ -132,7 +132,7 @@ const cropMap = {
 const ArticlePhotoCollection = ({
   caption,
   count,
-  items,
+  images,
   title,
   width,
 }) => (
@@ -140,29 +140,34 @@ const ArticlePhotoCollection = ({
     { title && <CollectionTitle>{title}</CollectionTitle> }
     <PhotoCollection className={`photo-collection__${width}`}>
       <ImagesWrapper>
-        {items.map((el, i) => {
+        {images.map((image, i) => {
           const imageClass = count === 2 ? 'two-up' : 'three-up';
-          const { altText: alt, photo } = el.attributes;
-          const ar = photo.contentWidth / photo.height;
+          const {
+            alt,
+            height: imageHeight,
+            publicId,
+            width: imageWidth,
+          } = image;
+          const ar = imageHeight && imageWidth ? imageWidth / imageHeight : null;
 
           return (
             <CollectionPicture
               className={`photo-collection__${imageClass}`}
-              key={`${photo.publicId.slice(-10)}-${i}`}
+              key={`${publicId.slice(-10)}-${i}`}
               width={width}
             >
               <source
-                srcSet={getImageUrl(photo.publicId, { aspectRatio: ar, ...cropMap.desktop[width][imageClass], crop: 'fill' })}
+                srcSet={getImageUrl(publicId, { aspectRatio: ar, ...cropMap.desktop[width][imageClass], crop: 'fill' })}
                 media="(min-width: 1136px)"
               />
               <source
-                srcSet={getImageUrl(photo.publicId, { aspectRatio: ar, ...cropMap.tablet[imageClass], crop: 'fill' })}
+                srcSet={getImageUrl(publicId, { aspectRatio: ar, ...cropMap.tablet[imageClass], crop: 'fill' })}
                 media="(min-width: 768px)"
               />
               <img
                 alt={alt}
                 className={`photo-${imageClass}`}
-                src={getImageUrl(photo.publicId, { aspectRatio: ar, ...cropMap.mobile[imageClass], crop: 'fill' })}
+                src={getImageUrl(publicId, { aspectRatio: ar, ...cropMap.mobile[imageClass], crop: 'fill' })}
               />
             </CollectionPicture>
           );
@@ -180,10 +185,15 @@ const ArticlePhotoCollection = ({
 );
 
 ArticlePhotoCollection.propTypes = {
+  /* Editorial caption for collection */
   caption: PropTypes.string,
+  /* Count of images, determines 2-up or 3-up treatment */
   count: PropTypes.oneOf([2, 3]).isRequired,
-  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  /* Array of image objects */
+  images: PropTypes.arrayOf(PropTypes.object).isRequired,
+  /* Heading level 3 title for collection */
   title: PropTypes.string,
+  /* Width configuration for ArticlePhotoCollection */
   width: PropTypes.oneOf(['default', 'wide']).isRequired,
 };
 


### PR DESCRIPTION
The final api response for this component differs from the preview we got so this component broke. I refactored the image destructuring slightly so it no longer depends on the api structure. Passing data appropriately to this component is now up to espresso.