### PR TITLE
Small Adjustment More QA

### DIFF
--- a/src/components/Ads/ReviewsAds/ReviewsMarketingHat/index.js
+++ b/src/components/Ads/ReviewsAds/ReviewsMarketingHat/index.js
@@ -83,6 +83,7 @@ const ContentWrapper = styled.div`
 
       &::placeholder {
         font: ${fontSize.md}/1rem ${font.pnr};
+        line-height: 2.1rem;
       }
     }
 

--- a/src/components/Newsletters/InlineNewsletter/index.js
+++ b/src/components/Newsletters/InlineNewsletter/index.js
@@ -60,6 +60,7 @@ const NewsletterSubtitle = styled.div.attrs({
 
 const NewsletterSuccessTheme = {
   default: css`
+    color: ${color.eclipse};
     font: ${fontSize.xl}/${lineHeight.sm} ${font.pnb};
     margin: 0 0 ${spacing.sm} ${spacing.xsm};
 


### PR DESCRIPTION
Updated Inline Newsletter success color on mobile & tablet and added line height for:
- On FireFox, the placeholder text in the email input field is not centered vertically.

Rebuilding to hopefully address difference between local and dev cutting off placeholder of email form input
