### PR TITLE
jb-ARCHIE-2580: Includes 2559 & 2560 QA touchups

### DIFF
--- a/src/components/Ads/ReviewsAds/CookingSchoolAd/index.js
+++ b/src/components/Ads/ReviewsAds/CookingSchoolAd/index.js
@@ -22,8 +22,18 @@ const AdDimensions = styled.div`
     flex-direction: row;
   `}
 
+  ${breakpoint('desktop')`
+    &.cooking-school-ad__detail {
+      justify-content: space-between;
+    }
+  `}
+
   ${breakpoint('xlg')`
     margin: auto;
+
+    &.cooking-school-ad__detail {
+      justify-content: unset;
+    }
     
     &.cooking-school-ad__landing {
       width: 113.6rem;
@@ -85,11 +95,12 @@ const AdWrapper = styled.div`
     }
   `}
 
-  ${breakpoint('lg')`
+  ${breakpoint('desktop')`
     &.cooking-school-ad__detail {
       margin: ${spacing.xlg} 0 2.2rem;
+      min-width: 66.7rem;
       padding: 2.2rem 3.6rem 2.2rem 2.3rem;
-      width: 66.7rem;
+      width: 100%;
     }
   `}
 
@@ -111,7 +122,7 @@ const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
 
-  ${breakpoint('lg')`
+  ${breakpoint('desktop')`
     &.cooking-school-ad__detail {
       max-width: 26rem;
     }
@@ -147,7 +158,7 @@ const CtaLink = styled.a`
     min-width: 19.7rem;
   `}
 
-  ${breakpoint('lg')`
+  ${breakpoint('desktop')`
     min-width: 17.7rem;
     margin-left: 2.5rem;
   `}

--- a/src/components/Ads/ReviewsAds/ReviewsEmailCapture/__tests__/ReviewsEmailCapture.spec.js
+++ b/src/components/Ads/ReviewsAds/ReviewsEmailCapture/__tests__/ReviewsEmailCapture.spec.js
@@ -31,6 +31,6 @@ describe('ReviewsEmailCapture', () => {
 
   it('renders success message', () => {
     renderComponent({ success: true });
-    expect(screen.getByText('Thank you! Get ready for watch and cook newsletter in your inbox.'));
+    expect(screen.getByText('Thank you! Get ready for Well-Equipped Cook in your inbox on Wednesdays!'));
   });
 });

--- a/src/components/Ads/ReviewsAds/ReviewsEmailCapture/index.js
+++ b/src/components/Ads/ReviewsAds/ReviewsEmailCapture/index.js
@@ -25,7 +25,7 @@ const AdDescription = styled.p`
     min-width: 35rem;
   `}
 
-  ${breakpoint('lg')`
+  ${breakpoint('desktop')`
     min-width: 34rem;
   `}
 
@@ -67,7 +67,7 @@ const AdTitle = styled.h2`
     margin-bottom: ${spacing.xxsm};
   `}
 
-  ${breakpoint('lg')`
+  ${breakpoint('desktop')`
     max-width: 32rem;
   `}
 
@@ -156,10 +156,11 @@ const AdWrapper = styled.div`
     }
   `}
 
-  ${breakpoint('lg')`
+  ${breakpoint('desktop')`
     margin: ${spacing.xlg} 0 0;
+    min-width: 66.7rem;
     padding: 2.5rem 3.65rem 3.45rem 3rem;
-    width: 66.7rem;
+    width: 100%;
 
     .email-form {
       margin-top: 1.5rem;
@@ -175,6 +176,7 @@ const AdWrapper = styled.div`
 
     .email-form {
       margin-top: 0;
+      min-width: 34rem;
     }
 `}
 `;
@@ -187,7 +189,7 @@ const MainContent = styled.div`
     max-width: 34rem;
   `}
 
-  ${breakpoint('lg')`
+  ${breakpoint('desktop')`
     margin-right: 0;
   `}
 
@@ -245,7 +247,7 @@ ReviewsEmailCapture.propTypes = {
 
 ReviewsEmailCapture.defaultProps = {
   success: false,
-  successText: 'Thank you! Get ready for watch and cook newsletter in your inbox.',
+  successText: 'Thank you! Get ready for Well-Equipped Cook in your inbox on Wednesdays!',
   ...EmailForm.defaultProps,
 };
 

--- a/src/components/Ads/ReviewsAds/ReviewsMarketingHat/index.js
+++ b/src/components/Ads/ReviewsAds/ReviewsMarketingHat/index.js
@@ -300,6 +300,7 @@ const ReviewsMarketingHat = ({
         {isAnonymous ? (
           <EmailForm
             buttonText={buttonText}
+            formId="hat-email-form"
             inputId={inputId}
             onSubmit={onSubmit}
             placeholder="Enter your email address"

--- a/src/components/Forms/EmailForm/index.js
+++ b/src/components/Forms/EmailForm/index.js
@@ -132,6 +132,7 @@ const EmailForm = ({
   buttonTextColor,
   buttonText,
   errorText,
+  formId,
   howWeUseText,
   inputId,
   inputLabel,
@@ -175,6 +176,7 @@ const EmailForm = ({
         buttonHoverTextColor={buttonHoverTextColor}
         buttonTextColor={buttonTextColor}
         disabled={disabled}
+        id={formId}
         onSubmit={handleSubmit}
       >
         <FormInput
@@ -232,6 +234,8 @@ EmailForm.propTypes = {
   buttonTextColor: PropTypes.string,
   buttonText: PropTypes.string,
   errorText: PropTypes.string,
+  /** Id used to gather innerHTML for order flow prefill */
+  formId: PropTypes.string,
   howWeUseText: PropTypes.string,
   inputId: PropTypes.string.isRequired,
   inputLabel: PropTypes.string,
@@ -247,6 +251,7 @@ EmailForm.defaultProps = {
   buttonHoverTextColor: 'white',
   buttonTextColor: 'white',
   buttonText: 'Sign me up',
+  formId: 'email-form',
   errorText: 'Invalid email address',
   howWeUseText: 'How we use your email address',
   inputLabel: 'Email address',

--- a/src/components/Newsletters/InlineNewsletter/index.js
+++ b/src/components/Newsletters/InlineNewsletter/index.js
@@ -216,7 +216,7 @@ InlineNewsletter.propTypes = {
 InlineNewsletter.defaultProps = {
   ...EmailForm.defaultProps,
   success: false,
-  successText: 'Thank you! Get ready for watch and cook newsletter in your inbox.',
+  successText: 'Thank you! Get ready for Well-Equipped Cook in your inbox on Wednesdays!',
   successDescription: null,
 };
 


### PR DESCRIPTION
- Updated Cooking school ad & WEC Newsletter breakpoint to desktop instead of lg to match DetailPageFull
- Updated WEC Success Text to Match ARCHIE-2580
- Added optional prop to email form we can use to select form and retrieve innerHTML for order flow redirect