### PR TITLE
Fix standard card title overlap

### DIFF
--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -78,7 +78,7 @@ const TitleWrapperTheme = {
     align-items: flex-start;
     justify-content: space-between;
     padding-top: ${spacing.xsm};
-    max-width: ${props => [props.displayFavoritesButton ? '24.5rem' : 'none']};
+    margin-right: ${props => [props.displayFavoritesButton ? spacing.sm : 'none']};
   `,
 };
 


### PR DESCRIPTION
Some titles on standard cards were overlapping favorite ribbons on mobile