### PR TITLE
Use defaultChecked attribute – fix build error

### DIFF
--- a/src/components/Algolia/shared/RefinementFilter/RefinementFilter.js
+++ b/src/components/Algolia/shared/RefinementFilter/RefinementFilter.js
@@ -216,7 +216,7 @@ const RefinementFilter = ({
       <RefinementFilterCheckbox
         id={`search-site-list--${value}`}
         type="checkbox"
-        checked={isRefined}
+        defaultChecked={isRefined}
       />
       {
         attribute === 'search_site_list' ? (


### PR DESCRIPTION
After I merged my last branch, the build was failing and complained about using a `checked` attribute instead of `defaultChecked`.