### PR TITLE
Increase margin to prevent outline overlapping favorites button

### DIFF
--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -78,7 +78,7 @@ const TitleWrapperTheme = {
     align-items: flex-start;
     justify-content: space-between;
     padding-top: ${spacing.xsm};
-    margin-right: ${props => [props.displayFavoritesButton ? spacing.sm : 'none']};
+    margin-right: ${props => [props.displayFavoritesButton ? spacing.md : 'none']};
   `,
 };
 


### PR DESCRIPTION
The outline was overlapping the favorites button in some cases