### PR TITLE
Rework Accordion markup and visually hidden status message

### DIFF
--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -5,9 +5,9 @@ import breakpoint from 'styled-components-breakpoint';
 
 import AccordionControl from '../AccordionControl';
 import { ChefHat, Content, Cookbook, Knife, Sort, Time } from '../DesignTokens/Icon/svgs';
-import { color, font, fontSize, letterSpacing, spacing, withThemes } from '../../styles';
+import { color, font, fontSize, letterSpacing, mixins, spacing, withThemes } from '../../styles';
 
-const AccordionDivWrapper = styled.div.attrs({
+const AccordionWrapper = styled.div.attrs({
   className: 'accordion-content-wrapper',
 })`
   &:focus-within {
@@ -18,10 +18,6 @@ const AccordionDivWrapper = styled.div.attrs({
     }
   }
 `;
-
-const AccordionFieldsetWrapper = styled.fieldset.attrs({
-  className: 'accordion-content-wrapper',
-})``;
 
 const AccordionButtonTheme = {
   default: css`
@@ -132,7 +128,7 @@ const AccordionLabelWrapperTheme = {
 
     ${({ hasIcon }) => (
     hasIcon ? `
-      legend {
+      .show-hide__button-label {
         display: inline-block;
         margin-right: ${spacing.xsm};
         max-width: 11.25rem;
@@ -151,7 +147,7 @@ const AccordionLabelWrapperTheme = {
   kidsSearch: css`
     flex-direction: row-reverse;
 
-    legend {
+    .show-hide__button-label {
       max-width: none;
     }
 
@@ -174,7 +170,15 @@ const AccordionLabelWrapper = styled.div.attrs({
   ${withThemes(AccordionLabelWrapperTheme)}
 `;
 
-const AccordionContent = styled.div`
+const AccordionFieldsetContent = styled.fieldset`
+  display: ${({ hidden }) => (hidden ? 'none' : 'block')};
+
+  @media print {
+    display: block !important;
+  }
+`;
+
+const AccordionDivContent = styled.div`
   display: ${({ hidden }) => (hidden ? 'none' : 'block')};
 
   @media print {
@@ -191,8 +195,12 @@ const icons = {
   time: Time,
 };
 
+const StyledLegend = styled.legend`
+  ${mixins.visuallyHidden};
+`;
+
 const Legend = ({ children }) => (
-  <legend>{children}</legend>
+  <StyledLegend>{children}</StyledLegend>
 );
 
 Legend.propTypes = {
@@ -214,7 +222,7 @@ function Accordion({
   onClick,
 }) {
   const [hidden, toggleHidden] = useState(isHidden);
-  const AccordionWrapper = isFieldset ? AccordionFieldsetWrapper : AccordionDivWrapper;
+  const AccordionContent = isFieldset ? AccordionFieldsetContent : AccordionDivContent;
   const Icon = icon ? icons[icon] : null;
   let idVal = id;
   if (!idVal && typeof Label === 'string') {
@@ -223,11 +231,7 @@ function Accordion({
 
   const isLabelString = typeof Label === 'string';
   let labelEl;
-  if (isFieldset) {
-    labelEl = isLabelString ? <Legend>{Label}</Legend> : <Label />;
-  } else {
-    labelEl = isLabelString ? Label : <Label />;
-  }
+  labelEl = isLabelString ? Label : <Label />;
 
   if (typeof Label === 'object') {
     labelEl = Label;
@@ -254,7 +258,7 @@ function Accordion({
         {
           isFieldset ? (
             <AccordionLabelWrapper hasIcon={icon}>
-              {labelEl}
+              <span className="show-hide__button-label">{labelEl}</span>
               {Icon ? <Icon className={`show-hide__icon--${icon}`} /> : null}
             </AccordionLabelWrapper>
           ) : labelEl
@@ -264,6 +268,7 @@ function Accordion({
           isExpanded={!hidden}
         />
       </AccordionButton>
+      {isFieldset ? <Legend>{Label}</Legend> : null}
       <AccordionContent
         data-testid="accordion-content"
         id={`show-hide--${idVal}`}

--- a/src/components/Algolia/search/SearchNumericMenu/__tests__/SearchNumericMenu.spec.js
+++ b/src/components/Algolia/search/SearchNumericMenu/__tests__/SearchNumericMenu.spec.js
@@ -31,6 +31,6 @@ describe('SearchNumericMenu component should', () => {
 
   it('render an Accordion with label \'Overall Time\'', () => {
     renderComponent();
-    expect(screen.getByText('Overall Time'));
+    expect(screen.getAllByText('Overall Time'));
   });
 });

--- a/src/components/Algolia/search/SearchSortBy/__tests__/SearchSortBy.spec.js
+++ b/src/components/Algolia/search/SearchSortBy/__tests__/SearchSortBy.spec.js
@@ -21,7 +21,7 @@ describe('SearchSortBy component should', () => {
 
   it('render an Accordion with label \'Sort By\'', () => {
     renderComponent();
-    expect(screen.getByText('Sort By'));
+    expect(screen.getAllByText('Sort By'));
   });
 
   it('render a sorting filters with appropriate labels', () => {

--- a/src/components/Algolia/shared/SortBy/index.js
+++ b/src/components/Algolia/shared/SortBy/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { connectSortBy } from 'react-instantsearch-dom';
@@ -12,6 +12,13 @@ import {
   spacing,
   withThemes,
 } from '../../../../styles';
+
+const SearchSortByStatus = styled.div.attrs({
+  className: 'sort-by__status',
+  role: 'status',
+})`
+  ${mixins.visuallyHidden};
+`;
 
 const SearchSortByItemTheme = {
   default: css`
@@ -98,10 +105,6 @@ const SearchSortByLabelTheme = {
       ${mixins.focusIndicator()};
       outline-offset: 0;
     }
-
-    .sort-by__status {
-      ${mixins.visuallyHidden};
-    }
   `,
   kidsSearch: css`
     background-color: ${color.greySmoke};
@@ -143,9 +146,21 @@ const SearchSortByLabel = styled.label.attrs({
   className: 'search-sort-by__label',
 })`${withThemes(SearchSortByLabelTheme)}`;
 
-export const CustomSortBy = ({ items, refine }) => (
-  <>
-    {
+export const CustomSortBy = ({ items, refine }) => {
+  // determine if the status message should reflect a preselected refinement
+  const defaultRefinement = (items) => {
+    const refined = items.filter(el => el.isRefined);
+    return refined[0]?.label || null;
+  };
+
+  const [status, setStatus] = useState(defaultRefinement(items));
+
+  return (
+    <>
+      {status && (
+        <SearchSortByStatus>Results sorted by {status}</SearchSortByStatus>
+      )}
+      {
       items.map(({ isRefined, label, value }) => (
         <SearchSortByItem
           key={value}
@@ -156,7 +171,11 @@ export const CustomSortBy = ({ items, refine }) => (
             <SearchSortByRadioInput
               defaultChecked={isRefined}
               className={isRefined ? 'refined' : ''}
-              onClick={(e) => { e.preventDefault(); refine(value); }}
+              onClick={(e) => {
+                e.preventDefault();
+                refine(value);
+                setStatus(label);
+              }}
               type="radio"
             />
             <SearchSortByCircle
@@ -164,13 +183,13 @@ export const CustomSortBy = ({ items, refine }) => (
               isRefined={isRefined}
             />
             {label}
-            {isRefined ? <div className="sort-by__status" role="status">Results sorted by {label}</div> : null }
           </SearchSortByLabel>
         </SearchSortByItem>
       ))
     }
-  </>
-);
+    </>
+  );
+};
 
 CustomSortBy.propTypes = {
   items: PropTypes.array.isRequired,


### PR DESCRIPTION
Rework the `Accordion` markup because way we were using `fieldset` and `legend` (nested inside a `button`) wasn't quite right and screen readers were not recognizing them. 

Also, we needed to include a visually hidden status message that gets announced when the sort by selection changes.