### PR TITLE
jb-ARCHIE-2658

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atk/mise-ui",
-  "version": "1.8.3--canary.89b52e3.0",
+  "version": "1.17.1--canary.2f8e0f7.0",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.14.5",
     "algoliasearch": "^4.0.3",

--- a/src/components/Cards/ReviewableSummaryCard/index.js
+++ b/src/components/Cards/ReviewableSummaryCard/index.js
@@ -220,8 +220,9 @@ const ReviewableSummaryCard = React.memo(({
   const isDiscontinued = price?.toLowerCase()?.includes('discontinued') ?? false;
   const priceMarkup = price?.replace(parensRe, '<span>$1</span>') ?? null;
   let buyNowIcon = asin ? 'Amazon' : null;
-  if (buyNowOverrideAffiliateActive && buyNowOverrideAffiliateName) {
-    buyNowIcon = buyNowOverrideAffiliateName;
+
+  if (buyNowOverrideAffiliateActive) {
+    buyNowIcon = buyNowOverrideAffiliateName || null;
   }
   const sortOfWinner = winner || isShortList;
   const stickerText = sortOfWinner


### PR DESCRIPTION
If `buyNowOverrideAffiliateActive` is active and `buyNowOverrideAffiliateName` doesn't come from our list of affiliates don't default to amazon icon - only return button
