### PR TITLE
ARCHIE-2175: themeing PullQuote, adding control addon to storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,5 +9,6 @@ module.exports = {
     '@storybook/addon-viewport/register',
     '@whitespace/storybook-addon-html',
     '@storybook/addon-notes/register',
+    '@storybook/addon-controls',
   ],
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,8 +8,8 @@ import globalStyles from '../src/styles/global';
 const theme = { breakpoints };
 
 export const decorators = [
-  (Story) => (
-      <ThemeProvider theme={theme}>
+  (Story, { args }) => (
+      <ThemeProvider theme={{ ...theme, siteKey: args.siteKey || null }}>
         <GlobalStyle />
         <Story />
       </ThemeProvider>

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.14.5",
     "@storybook/addon-actions": "^6.3.6",
+    "@storybook/addon-controls": "^6.3.6",
     "@storybook/addon-docs": "^6.3.6",
     "@storybook/addon-knobs": "^6.2.9",
     "@storybook/addon-links": "^6.3.6",

--- a/src/argTypes/index.js
+++ b/src/argTypes/index.js
@@ -1,0 +1,8 @@
+export const siteKey = {
+  options: ['atk', 'cco', 'cio'],
+  control: { type: 'radio' },
+};
+
+export default {
+  siteKey,
+};

--- a/src/components/Articles/PullQuote/PullQuote.stories.js
+++ b/src/components/Articles/PullQuote/PullQuote.stories.js
@@ -1,53 +1,25 @@
 import React from 'react';
 
 import PullQuote from './index';
+import { siteKey } from '../../../argTypes';
 
 export default {
   title: 'Components/Articles/PullQuote',
   component: PullQuote,
+  argTypes: { siteKey },
 };
 
-export const DefaultWithAttribution = () => (
-  <PullQuote
-    attribution="First Last"
-    quote="All blue cheeses are made with the same species of mold, Penicillium roqueforti."
-  />
-);
+const Template = (args) => <PullQuote {...args} />;
 
-export const DefaultWithoutAttribution = () => (
-  <PullQuote
-    quote="All blue cheeses are made with the same species of mold, Penicillium roqueforti."
-  />
-);
+const sharedArgs = {
+  attribution: 'First Last',
+  includeIcon: true,
+  quote: 'Cast iron skillets are endlessly enjoyable. You can hand down these pans for generations.',
+  siteKey: 'atk'
+};
 
-export const DefaultWithoutIcon = () => (
-  <PullQuote
-    attribution="First Last"
-    includeIcon={false}
-    quote="All blue cheeses are made with the same species of mold, Penicillium roqueforti."
-  />
-);
+export const DefaultWidth = Template.bind({});
+DefaultWidth.args = { ...sharedArgs, width: 'default' };
 
-export const WideWithAttribution = () => (
-  <PullQuote
-    attribution="First Last"
-    quote="All blue cheeses are made with the same species of mold, Penicillium roqueforti."
-    width="wide"
-  />
-);
-
-export const WideWithoutAttribution = () => (
-  <PullQuote
-    quote="All blue cheeses are made with the same species of mold, Penicillium roqueforti."
-    width="wide"
-  />
-);
-
-export const WideWithoutIcon = () => (
-  <PullQuote
-    attribution="First Last"
-    includeIcon={false}
-    quote="All blue cheeses are made with the same species of mold, Penicillium roqueforti."
-    width="wide"
-  />
-);
+export const WideWidth = Template.bind({});
+WideWidth.args = { ...sharedArgs, width: 'wide' };

--- a/src/components/Articles/PullQuote/index.js
+++ b/src/components/Articles/PullQuote/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 
 import ArticleFigcaption from '../shared/ArticleFigcaption';
 import { Quote } from '../../DesignTokens/Icon/svgs';
-import { color, font, fontSize, mixins } from '../../../styles';
+import { color, font, fontSize, mixins, withThemes } from '../../../styles';
 
 const PullQuoteWrapper = styled.div`
   display: flex;
@@ -23,20 +23,47 @@ const PullQuoteWrapper = styled.div`
   `}
 `;
 
+const PullQuoteIconTheme = {
+  default: css`
+    height: 3rem;
+    margin-bottom: 0.8rem;
+    min-width: 3rem;
+    width: 3rem;
+
+    svg {
+      height: 100%;
+      width: 100%;
+    }
+
+    ${breakpoint('md')`
+      margin-right: 1.6rem;
+    `}
+  `,
+  atk: css`
+    svg {
+      circle {
+        fill: ${color.mint};
+      }
+    }
+  `,
+  cco: css`
+    svg {
+      circle {
+        fill: ${color.denim};
+      }
+    }
+  `,
+  cio: css`
+    svg {
+      circle {
+        fill: ${color.squirrel};
+      }
+    }
+  `,
+};
+
 const PullQuoteIcon = styled.div`
-  height: 3rem;
-  margin-bottom: 0.8rem;
-  min-width: 3rem;
-  width: 3rem;
-
-  svg {
-    height: 100%;
-    width: 100%;
-  }
-
-  ${breakpoint('md')`
-    margin-right: 1.6rem;
-  `}
+  ${withThemes(PullQuoteIconTheme)}
 `;
 
 const PullQuoteFigure = styled.figure`
@@ -50,13 +77,33 @@ const PullQuoteFigure = styled.figure`
   `}
 `;
 
+const PullQuoteBlockQuoteTheme = {
+  default: css`
+    font-size: ${fontSize.xl};
+    line-height: 1.3;
+    margin: 0 0 1.2rem 0;
+    padding: 0;
+  `,
+  atk: css`
+    color: ${color.eclipse};
+    font-family: ${font.mwr};
+    font-style: italic;
+    font-weight: bold;
+  `,
+  cco: css`
+    color: ${color.black};
+    font-family: ${font.clb};
+  `,
+  cio: css`
+    color: ${color.cork};
+    font-family: ${font.mwr};
+    font-style: italic;
+    font-weight: bold;
+  `,
+};
+
 const PullQuoteBlockQuote = styled.blockquote`
-  color: ${color.eclipse};
-  font: ${fontSize.xl}/1.3 ${font.mwr};
-  font-style: italic;
-  font-weight: bold;
-  margin: 0 0 1.2rem 0;
-  padding: 0;
+  ${withThemes(PullQuoteBlockQuoteTheme)}
 `;
 
 const PullQuote = ({ attribution, includeIcon, quote, width }) => (

--- a/src/components/Articles/shared/ArticleFigcaption/index.js
+++ b/src/components/Articles/shared/ArticleFigcaption/index.js
@@ -1,47 +1,75 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 
-import { color, font, fontSize, mixins } from '../../../../styles';
+import { color, font, fontSize, mixins, withThemes } from '../../../../styles';
 
-const ArticleFigcaptionWrapper = styled.figcaption`
-  color: ${color.mediumGray};
-  font: ${fontSize.md}/1.5 ${font.pnb};
-  position: relative;
-
-  ${breakpoint('xs', 'xlg')`
-    padding-bottom: 0.8rem;
-  `}
-
-  ${breakpoint('xlg')`
-    ${({ decorationPosition }) => (decorationPosition === 'bottom' ? 'padding-bottom: 0.8rem;' : 'padding-top: 0.8rem;')}
-  `}
-
-  a {
-    ${mixins.styledLink(color.turquoise, color.seaSalt)}
-  }
-
-  &::after {
-    background-color: ${color.mint};
-    content: '';
-    display: block;
-    height: 0.6rem;
-    position: absolute;
-    width: 1.6rem;
+const ArticleFigcaptionTheme = {
+  default: css`
+    color: ${color.mediumGray};
+    font: ${fontSize.md}/1.5 ${font.pnb};
+    position: relative;
 
     ${breakpoint('xs', 'xlg')`
-      bottom: 0;
+      padding-bottom: 0.8rem;
     `}
 
     ${breakpoint('xlg')`
-      ${({ decorationPosition }) => (decorationPosition === 'bottom' ? 'bottom: 0;' : 'top: 0;')}
+      ${({ decorationPosition }) => (decorationPosition === 'bottom' ? 'padding-bottom: 0.8rem;' : 'padding-top: 0.8rem;')}
     `}
-  }
 
-  a {
-    ${mixins.styledLink(color.turquoise, color.seaSalt)}
-  }
+    &::after {
+      content: '';
+      display: block;
+      height: 0.6rem;
+      position: absolute;
+      width: 1.6rem;
+
+      ${breakpoint('xs', 'xlg')`
+        bottom: 0;
+      `}
+
+      ${breakpoint('xlg')`
+        ${({ decorationPosition }) => (decorationPosition === 'bottom' ? 'bottom: 0;' : 'top: 0;')}
+      `}
+    }
+
+    a {
+      ${mixins.styledLink(color.turquoise, color.seaSalt)}
+    }
+  `,
+  atk: css`
+    a {
+      ${mixins.styledLink(color.turquoise, color.seaSalt)}
+    }
+
+    &::after {
+      background-color: ${color.mint};
+    }
+  `,
+  cco: css`
+    a {
+      ${mixins.styledLink(color.malibu, color.cornflower)}
+    }
+
+    &::after {
+      background-color: ${color.denim};
+    }
+  `,
+  cio: css`
+    a {
+      ${mixins.styledLink(color.dijon, color.sand)}
+    }
+
+    &::after {
+      background-color: ${color.squirrel};
+    }
+  `,
+};
+
+const ArticleFigcaptionWrapper = styled.figcaption`
+  ${withThemes(ArticleFigcaptionTheme)}
 `;
 
 const ArticleFigcaption = ({ caption, decorationPosition }) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2383,6 +2383,20 @@
     util-deprecate "^1.0.2"
     uuid-browser "^3.1.0"
 
+"@storybook/addon-controls@^6.3.6":
+  version "6.3.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.3.6.tgz#2f8071e5b521375aace60af96e33a19f016581c9"
+  integrity sha512-wTWmnZl2qEAUqgLh8a7TL5f6w37Q51lAoJNlwxFFBSKtGS7xFUnou4qTUArNy5iKu1cWoVvofJ9RnP1maGByYA==
+  dependencies:
+    "@storybook/addons" "6.3.6"
+    "@storybook/api" "6.3.6"
+    "@storybook/client-api" "6.3.6"
+    "@storybook/components" "6.3.6"
+    "@storybook/node-logger" "6.3.6"
+    "@storybook/theming" "6.3.6"
+    core-js "^3.8.2"
+    ts-dedent "^2.0.0"
+
 "@storybook/addon-docs@^6.3.6":
   version "6.3.6"
   resolved "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.3.6.tgz"


### PR DESCRIPTION
Since Alex upgraded mise to Storybook 6 I decided to take a look at some new features/guidelines Storybook wrote for creating stories. I updated the `PullQuote` story to use these new guidelines. The doc pages I used to make updates were: [Args](https://storybook.js.org/docs/react/writing-stories/args), [ArgTypes](https://storybook.js.org/docs/react/api/argtypes), and [Controls](https://storybook.js.org/docs/react/essentials/controls).

Args map to props on a component, ArgTypes are objects you can use to define specific values and controls for Args, and Controls expose Args to users and let them be changed based on PropTypes or ArgTypes (similarly to knobs which will be replaced completely by Controls in Storybook 7). I think using controls could help use reduce the number of stories we have to write/maintain (ArticleTextBlock has a ton). It also gives QA/PO's and others easy an easy way to cycle through themes on components and also change certain configurations.