### PR TITLE
optimizing Image component IntersectionObserver

### DIFF
--- a/src/components/Cards/shared/Image/index.js
+++ b/src/components/Cards/shared/Image/index.js
@@ -24,12 +24,13 @@ const Image = ({
 }) => {
   const intersectionRef = useRef(null);
   const isPrint = useMedia('print');
+  const [imageLoaded, setImageLoaded] = useState(!lazy);
 
   const { isIntersecting } = useIntersection(intersectionRef, {
     root: null,
     rootMargin: lowQualityImageUrl ? '0px' : '30px',
     threshold: 0,
-  }) || { isIntersecting: false };
+  }, imageLoaded) || { isIntersecting: false };
 
   let initSrc = lazy ? inlineSrc : imageUrl;
   if (lazy && lowQualityImageUrl) {
@@ -39,6 +40,7 @@ const Image = ({
 
   const loadImage = useCallback(() => {
     setSrc(imageUrl);
+    setImageLoaded(true);
   }, [imageUrl]);
 
   useEffect(() => {

--- a/src/components/hooks/useIntersection.js
+++ b/src/components/hooks/useIntersection.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-const useIntersection = (ref, options) => {
+const useIntersection = (ref, options, componentLoaded) => {
   const [intersectionObserverEntry, setIntersectionObserverEntry] = useState(null);
   useEffect(() => {
     if (ref.current && typeof IntersectionObserver === 'function') {
@@ -9,13 +9,14 @@ const useIntersection = (ref, options) => {
       };
       const observer = new IntersectionObserver(handler, options);
       observer.observe(ref.current);
+      if (componentLoaded) observer.disconnect();
       return () => {
         setIntersectionObserverEntry(null);
         observer.disconnect();
       };
     }
     return () => { };
-  }, [options.threshold, options.root, options.rootMargin, ref, options]);
+  }, [options.threshold, options.root, options.rootMargin, ref, options, componentLoaded]);
   return intersectionObserverEntry;
 };
 export default useIntersection;


### PR DESCRIPTION
The IntersectionObserver inside of this Image component was tanking scroll performance on pages that use the Image component. If you have 20 lazy loaded images on the page all of them would call an IntersectionObserver that never disconnected and continuously ran 😱. The observer will now disconnect after the image loads. Scroll fps improved from 17-24fps to 50-58 fps on equipment review pages.