### PR TITLE
Flickity ready event not working, setTimeout workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atk/mise-ui",
-  "version": "1.21.1--canary.927f63c.0",
+  "version": "1.23.1--canary.8851f93.0",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.14.5",
     "algoliasearch": "^4.0.3",

--- a/src/components/Carousels/Carousel/index.js
+++ b/src/components/Carousels/Carousel/index.js
@@ -306,7 +306,7 @@ const Carousel = ({
   useEffect(() => {
     if (flktyRef.current) flktyRef.current.destroy();
     if (items.length > 1 && elRef?.current) {
-      const opts = { ...defaultOptions, ...options, on: { ready: () => handleCellChange(0) } };
+      const opts = { ...defaultOptions, ...options };
       const flkty = getFlickityInstance(elRef.current, opts);
       const isEnabled = flkty.slides.length > 1;
       if (isEnabled === false) {
@@ -316,6 +316,8 @@ const Carousel = ({
       } else {
         flktyRef.current = flkty;
         flktyRef.current.on('change', handleCellChange);
+        // workaround for flickity 'ready' event not working
+        setTimeout(() => handleCellChange(0), 0);
       }
       setEnabled(isEnabled);
     }


### PR DESCRIPTION
The `ready` event in flickity is not firing properly. As a workaround, use `setTimeout` after we initialize the flickity instance in the Carousel component.