### PR TITLE
move dependencies to dev+peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,20 +12,18 @@
     "lodash.orderby": "^4.6.0",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.7.2",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
     "react-instantsearch-dom": "^6.3.0",
     "react-loadable": "^5.5.0",
     "react-loadable-visibility": "^3.0.2",
-    "react-scripts": "3.3.1",
-    "styled-components": "5.3.0",
     "styled-components-breakpoint": "2.1.1",
     "styled-normalize": "^8.0.7",
     "verge": "^1.10.2"
   },
   "peerDependencies": {
-    "react-dom": "^17.0.2",
-    "react-instantsearch-dom": "^6.3.0"
+    "react": ">=16",
+    "react-dom": ">=16",
+    "react-instantsearch-dom": "^6.3.0",
+    "styled-components": "5.3.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -58,6 +56,10 @@
     ]
   },
   "devDependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-scripts": "3.3.1",
+    "styled-components": "5.3.0",
     "@auto-it/all-contributors": "^10.29.3",
     "@auto-it/released": "^10.29.3",
     "@babel/cli": "^7.14.5",


### PR DESCRIPTION
To support different version of the react that matches the installers version, the dependencies normally linked and shared between apps and mise-ui have been moved to peer dependencies.

I also found [yalc](https://github.com/wclr/yalc) that avoids the documented symlink issues of development with yarn link. 