### PR TITLE
ts-support: Migration for all a_ components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -60,14 +60,19 @@
     "arrow-parens": [2, "as-needed", { "requireForBlockBody": true }],
     "react/jsx-props-no-spreading": 0,
     "react/jsx-fragments": 0,
-    "import/no-cycle": 0
+    "import/no-cycle": 0,
+    "react/require-default-props": [2, { "forbidDefaultForRequired": true, "ignoreFunctionalComponents": true }],
+    "@typescript-eslint/explicit-module-boundary-types": 0,
+    "@typescript-eslint/no-empty-function": 0
   },
   "extends": [
     "airbnb",
     "plugin:react-hooks/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:import/typescript"
+    "plugin:import/typescript",
+    "eslint:recommended", 
+    "plugin:@typescript-eslint/recommended"
   ],
   "plugins": [
     "import",

--- a/TYPESCRIPT.md
+++ b/TYPESCRIPT.md
@@ -1,0 +1,122 @@
+# Typescript Migrations
+
+## Prop Types
+
+1. Because of an issue with InferProps, Typescript props should be declared in addition to propType definitions. This will let us migrate to es6 default parameters, which are deprecated in react because of future limitations.
+
+Badge.js
+
+```javascript
+    import React from 'react';
+    import PropTypes from 'prop-types';
+
+    const Badge = ({ className, fill, type }) => {
+        return <div>{...}</div>
+    }
+
+    Badge.propTypes = {
+        className: PropTypes.string,
+        fill: PropTypes.string,
+        type: PropTypes.oneOf(['atk', 'cio', 'cco', 'kids', 'school', 'shop']).isRequired,
+    };
+
+    Badge.defaultProps = {
+        className: '',
+        fill: '#000000',
+    };
+
+    export default Badge;
+```
+
+Badge.tsx
+
+```typescript
+    import React, { ReactElement } from 'react';
+    import PropTypes from 'prop-types';
+
+    const BadgeProps = {
+        className?: string;
+        fill?: string;
+        type: 'atk' | 'cio' | 'cco' | 'kids' | 'school' | 'shop';
+    };
+
+    const Badge = ({ 
+        className, 
+        fill = '#000000', 
+        type 
+    }: BadgeProps): ReactElement => {
+        return <div>{...}</div>
+    }
+
+    Badge.propTypes = {
+        className: PropTypes.string,
+        fill: PropTypes.string,
+        type: PropTypes.oneOf(['atk', 'cio', 'cco', 'kids', 'school', 'shop']).isRequired,
+    };
+
+    export default Badge;
+```
+
+## Styled Components
+
+>  NOTE: likely room for improvement
+
+1. Omitted props workaround.
+
+    Styled components already provide typing for the underlying react element. Default values passed through attrs have their type narrowed from strings to string literals. So that any other string value passed throws an error.
+
+    `Type '"show-hide__expand-collapse-button"' is not assignable to type '"accordion-item__button" | undefined'.`
+
+    You can recast the value back to a string with `as string`
+
+    ```typescript
+    const AccordionButton = styled.button.attrs({
+        className: 'accordion-item__button' as string,
+    })`
+    ```
+
+    Additional workaround to ignore the type inference.
+
+    ```typescript
+    const AccordionButton = styled.button.attrs<{}>({
+        className: 'accordion-item__button',
+    })`
+    ```
+
+2. Adding pass through properties.
+
+    You can pass multiple generics after `.attrs` and before `({` but it seems that passing a single definition between `})` and  `.
+
+    ```typescript
+    const AccordionButton = styled.button.attrs({
+        className: 'accordion-item__button' as string,
+    })<{ hasIcon?: keyof typeof icons }>`
+    ```
+3. I ran into issues with merging the DefaultTheme definition for styled components. For now explicitly defining types is more than acceptable. Put you object definition between `css` and `.
+
+    ```typescript
+    const HeroAdInnerWrapperTheme = {
+        default: css<{ backgroundColor: keyof typeof color }>`
+            background-color: ${({ backgroundColor }) => `${color[backgroundColor] || 'transparent'}`};
+        `
+    }
+    ```
+
+## Misc
+
+1. Pass through with ...restProps.
+
+    If you run into a component that passes through properties. These are often used to point to a dom element directly and may expect those dom typings. While many will get inferred through styled components, there are some that need explicit definitions. Use `React.ComponentPropsWithoutRef` for element definitions, and combine with either interface extension or unions with types to add on new properties.
+
+    ```typescript
+        import React, { 
+            ReactElement, 
+            ComponentPropsWithoutRef 
+        } from 'react';
+
+        type MyButtonProps = ComponentPropsWithoutRef<'button'>;
+
+        const MyButton = ({ children, type, ...restProps }: MyButtonProps): ReactElement => (
+            <button type={type === 'submit' ? 'submit' : 'button'} {...restProps}>{children}</button>
+        );
+    ```

--- a/src/components/AccordionControl/index.tsx
+++ b/src/components/AccordionControl/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
@@ -7,7 +7,7 @@ import { color, withThemes } from '../../styles';
 import { Plus } from '../DesignTokens/Icon/svgs';
 
 const AccordionSvgWrapperTheme = {
-  default: css`
+  default: css<{ isExpanded: boolean }>`
     height: 2rem;
     max-height: 2rem;
     max-width: 2rem;
@@ -137,11 +137,19 @@ const AccordionSvgWrapperTheme = {
 
 const AccordionSvgWrapperEl = styled.div.attrs({
   className: 'accordion-item__icon',
-})`
+})<{ isExpanded: boolean }>`
   ${withThemes(AccordionSvgWrapperTheme)}
 `;
 
-const AccordionControl = ({ iconSize, isExpanded }) => (
+type AccordionControlProps = {
+  iconSize?: 'default' | 'large' | 'extraLarge';
+  isExpanded: boolean;
+};
+
+const AccordionControl = ({
+  iconSize = 'default',
+  isExpanded,
+}: AccordionControlProps): ReactElement => (
   <AccordionSvgWrapperEl
     isExpanded={isExpanded}
   >
@@ -149,13 +157,10 @@ const AccordionControl = ({ iconSize, isExpanded }) => (
   </AccordionSvgWrapperEl>
 );
 
+// TODO: remove when fully typescript
 AccordionControl.propTypes = {
   iconSize: PropTypes.oneOf(['default', 'large', 'extraLarge']),
   isExpanded: PropTypes.bool.isRequired,
-};
-
-AccordionControl.defaultProps = {
-  iconSize: 'default',
 };
 
 export default AccordionControl;

--- a/src/components/Ads/HeroAd/index.tsx
+++ b/src/components/Ads/HeroAd/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 import { getImageUrl } from '../../../lib/cloudinary';
 import {
@@ -35,7 +35,7 @@ const HeroAdWrapper = styled.div.attrs({
  * Wrapper inner (background-color)
  */
 const HeroAdInnerWrapperTheme = {
-  default: css`
+  default: css<{ backgroundColor: keyof typeof color }>`
     background-color: ${({ backgroundColor }) => `${color[backgroundColor] || 'transparent'}`};
     padding: 0 ${spacing.sm};
     position: relative;
@@ -54,7 +54,7 @@ const HeroAdInnerWrapperTheme = {
 
 const HeroAdInnerWrapper = styled.div.attrs({
   className: 'hero-ad__inner',
-})`${withThemes(HeroAdInnerWrapperTheme)}`;
+})<{ backgroundColor?: string }>`${withThemes(HeroAdInnerWrapperTheme)}`;
 
 /**
  * Content (title, subtitle, button, cta)
@@ -164,7 +164,7 @@ const HeroAdImage = styled.img.attrs({
  * Hero ad cta button
  */
 const HeroAdCtaTheme = {
-  default: css`
+  default: css<{ backgroundColor: keyof typeof color, hoverColor: keyof typeof color}>`
     color: ${color.white};
     background-color: ${({ backgroundColor }) => `${color[backgroundColor || 'eclipse']}`};
     display: block;
@@ -187,11 +187,27 @@ const HeroAdCtaTheme = {
 
 const HeroAdCta = styled.span.attrs({
   className: 'hero-ad__cta',
-})`${withThemes(HeroAdCtaTheme)}`;
+})<{
+  backgroundColor?: string,
+  hoverColor?: string
+}>`${withThemes(HeroAdCtaTheme)}`;
+
+type HeroAdsProps = {
+  backgroundColor?: string;
+  buttonHoverColor?: string;
+  buttonColor?: string;
+  cloudinaryId: string;
+  cta: string;
+  ctaHref: string,
+  ctaTarget?: string,
+  onClick?: () => void,
+  subtitle?: string;
+  title: string;
+};
 
 const HeroAds = ({
-  backgroundColor,
-  buttonColor,
+  backgroundColor = 'transparent',
+  buttonColor = 'tomato',
   buttonHoverColor,
   cloudinaryId,
   cta,
@@ -200,7 +216,7 @@ const HeroAds = ({
   onClick,
   subtitle,
   title,
-}) => (
+}: HeroAdsProps): ReactElement => (
   <HeroAdWrapper>
     <a
       href={ctaHref}
@@ -231,8 +247,8 @@ const HeroAds = ({
           />
           <HeroAdCta
             backgroundColor={buttonColor}
-            data-testid="hero-ad__cta"
             hoverColor={buttonHoverColor}
+            data-testid="hero-ad__cta"
           >
             {cta}
           </HeroAdCta>
@@ -242,6 +258,7 @@ const HeroAds = ({
   </HeroAdWrapper>
 );
 
+// TODO: remove when fully typescript
 HeroAds.propTypes = {
   backgroundColor: PropTypes.string,
   buttonColor: PropTypes.string,
@@ -253,15 +270,6 @@ HeroAds.propTypes = {
   onClick: PropTypes.func,
   subtitle: PropTypes.string,
   title: PropTypes.string.isRequired,
-};
-
-HeroAds.defaultProps = {
-  backgroundColor: 'transparent',
-  buttonColor: 'tomato',
-  buttonHoverColor: null,
-  ctaTarget: null,
-  onClick: null,
-  subtitle: null,
 };
 
 export default HeroAds;

--- a/src/components/Ads/PairedProductAd/index.tsx
+++ b/src/components/Ads/PairedProductAd/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 
 import { getImageUrl } from '../../../lib/cloudinary';
@@ -236,7 +236,26 @@ const PairedProductCta = styled.a.attrs({
   className: 'paired-product__cta',
 })`${withThemes(PairedProductCtaTheme)}`;
 
-const PairedProducts = ({ onClick, products, title }) => (
+type Product = {
+  cloudinaryId: string;
+  cta: string;
+  ctaHref: string;
+  ctaTarget?: string;
+  subtitle: string;
+  title: string;
+}
+
+type PairedProductsProps = {
+  title: string;
+  onClick?: () => void;
+  products: Product[];
+};
+
+const PairedProducts = ({
+  onClick,
+  products,
+  title,
+}: PairedProductsProps): ReactElement => (
   <PairedProductWrapper>
     <PairedProductInnerWrapper>
       <PairedProductMainTitle>
@@ -294,12 +313,8 @@ PairedProducts.propTypes = {
       ctaTarget: PropTypes.string,
       subtitle: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired,
-    }),
+    } as const).isRequired,
   ).isRequired,
-};
-
-PairedProducts.defaultProps = {
-  onClick: null,
 };
 
 export default PairedProducts;

--- a/src/components/Ads/ReviewsAds/BookCarouselAd/index.tsx
+++ b/src/components/Ads/ReviewsAds/BookCarouselAd/index.tsx
@@ -1,6 +1,5 @@
-// import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled from 'styled-components';
 
 import Image from '../../../Cards/shared/Image';
@@ -65,19 +64,34 @@ const AdWrapper = styled.div`
   }
 `;
 
+const BookCarouselAdDefaults = {
+  cloudinaryId: 'ATK Reviews Ads/Mask_Group_49066_3x.jpg',
+  ctaLinkText: 'Save 56% Now',
+  hrefUrl: 'https://shop.americastestkitchen.com/complete-atk-21.html',
+  title: 'Every Recipe (1,670!) From All 21 Seasons',
+};
+
+type BookCarouselAdProps = {
+  cloudinaryId?: string;
+  ctaLinkText?: string;
+  hrefUrl?: string;
+  sourceKey: string;
+  title?: string;
+};
+
 const BookCarouselAd = ({
-  cloudinaryId,
-  ctaLinkText,
-  hrefUrl,
+  cloudinaryId = BookCarouselAdDefaults.cloudinaryId,
+  ctaLinkText = BookCarouselAdDefaults.ctaLinkText,
+  hrefUrl = BookCarouselAdDefaults.hrefUrl,
   sourceKey,
-  title,
-}) => (
+  title = BookCarouselAdDefaults.title,
+}: BookCarouselAdProps): ReactElement => (
   <AdWrapper>
     <AdTitle>{title}</AdTitle>
     <Image
       className="book-carousel-ad__image"
       imageAlt="The Complete America's Test Kitchen TV Show Cookbook"
-      imageUrl={getImageUrl(cloudinaryId, { aspectRatio: '816:1200', width: 272, height: 400 })}
+      imageUrl={cloudinaryId ? getImageUrl(cloudinaryId, { aspectRatio: '816:1200', width: 272, height: 400 }) : ''}
     />
     <AdCtaLink href={`${hrefUrl}?sourcekey=${sourceKey}`} target="_blank">{ctaLinkText}</AdCtaLink>
   </AdWrapper>
@@ -89,13 +103,6 @@ BookCarouselAd.propTypes = {
   hrefUrl: PropTypes.string,
   sourceKey: PropTypes.string.isRequired,
   title: PropTypes.string,
-};
-
-BookCarouselAd.defaultProps = {
-  cloudinaryId: 'ATK Reviews Ads/Mask_Group_49066_3x.jpg',
-  ctaLinkText: 'Save 56% Now',
-  hrefUrl: 'https://shop.americastestkitchen.com/complete-atk-21.html',
-  title: 'Every Recipe (1,670!) From All 21 Seasons',
 };
 
 export default BookCarouselAd;

--- a/src/components/Ads/ReviewsAds/CookingSchoolAd/index.tsx
+++ b/src/components/Ads/ReviewsAds/CookingSchoolAd/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 
 import {
@@ -310,17 +310,37 @@ const MainContent = styled.div`
   `}
 `;
 
+const CookingSchoolAdDefaults = {
+  cloudinaryId: 'ATK Reviews Ads/CAN_CookingSchoolGeneralCandids-9031_3x.png',
+  description: 'Take your skills to the next level with 320+ courses led by our expert test cooks.',
+  headline: 'Try our online cooking school',
+  linkCta: 'Try for Free',
+  mobileLinkCta: 'Try Now',
+};
+
+type CookingSchoolAdProps = {
+  cloudinaryId?: string;
+  description?: string;
+  deviceType: string;
+  headline?: string;
+  identifier: 'landing' | 'detail';
+  href: string;
+  linkCta?: string;
+  mobileLinkCta?: string;
+  onClick: () => void;
+};
+
 const CookingSchoolAd = ({
-  linkCta,
-  cloudinaryId,
-  description,
+  linkCta = CookingSchoolAdDefaults.linkCta,
+  cloudinaryId = CookingSchoolAdDefaults.cloudinaryId,
+  description = CookingSchoolAdDefaults.description,
   deviceType,
-  headline,
+  headline = CookingSchoolAdDefaults.headline,
   href,
   identifier,
-  mobileLinkCta,
+  mobileLinkCta = CookingSchoolAdDefaults.mobileLinkCta,
   onClick,
-}) => (
+}: CookingSchoolAdProps): ReactElement => (
   <AdWrapper className={`cooking-school-ad__${identifier}`}>
     <AdDimensions
       className={`cooking-school-ad__${identifier}`}
@@ -330,13 +350,13 @@ const CookingSchoolAd = ({
       <MainContent className={`cooking-school-ad__${identifier}`}>
         <AdPicture className={`cooking-school-ad__${identifier}`}>
           <source
-            src={getImageUrl(cloudinaryId, { aspectRatio: '1:1', width: 500 })}
+            src={cloudinaryId ? getImageUrl(cloudinaryId, { aspectRatio: '1:1', width: 500 }) : ''}
             media="(min-width: 768)"
           />
           <img
             alt=""
             className="cooking-school-ad__image"
-            src={getImageUrl(cloudinaryId, { aspectRatio: '1:1', width: 400 })}
+            src={cloudinaryId ? getImageUrl(cloudinaryId, { aspectRatio: '1:1', width: 400 }) : ''}
           />
         </AdPicture>
         <ContentWrapper className={`cooking-school-ad__${identifier}`}>
@@ -363,14 +383,6 @@ CookingSchoolAd.propTypes = {
   linkCta: PropTypes.string,
   mobileLinkCta: PropTypes.string,
   onClick: PropTypes.func.isRequired,
-};
-
-CookingSchoolAd.defaultProps = {
-  cloudinaryId: 'ATK Reviews Ads/CAN_CookingSchoolGeneralCandids-9031_3x.png',
-  description: 'Take your skills to the next level with 320+ courses led by our expert test cooks.',
-  headline: 'Try our online cooking school',
-  linkCta: 'Try for Free',
-  mobileLinkCta: 'Try Now',
 };
 
 export default CookingSchoolAd;

--- a/src/components/Ads/ReviewsAds/ReviewsEmailCapture/index.tsx
+++ b/src/components/Ads/ReviewsAds/ReviewsEmailCapture/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 
 import {
@@ -285,7 +285,7 @@ const AdWrapperTheme = {
   `,
 };
 
-const AdWrapper = styled.div`
+const AdWrapper = styled.div<{ success?: boolean }>`
   ${withThemes(AdWrapperTheme)}
 `;
 
@@ -306,14 +306,33 @@ const MainContent = styled.div`
   `}
 `;
 
+const ReviewsEmailCaptureDefaults = {
+  success: false,
+  successText: 'Thank you! Get ready for Well-Equipped Cook in your inbox on Wednesdays!',
+};
+
+type ReviewsEmailCaptureProps = {
+  buttonTextColor?: string;
+  buttonText?: string;
+  description: string;
+  errorText?: string;
+  inputLabel?: string;
+  inputId: string;
+  onSubmit: (email: string) => void;
+  placeholder?: string;
+  success?: boolean;
+  successText?: string;
+  title: string;
+};
+
 const ReviewsEmailCapture = ({
   description,
   onSubmit,
-  success,
-  successText,
+  success = ReviewsEmailCaptureDefaults.success,
+  successText = ReviewsEmailCaptureDefaults.successText,
   title,
-  ...emailFormProps
-}) => (
+  ...restProps
+}: ReviewsEmailCaptureProps): ReactElement => (
   <AdWrapper success={success}>
     <MainContent>
       <AdTitle>{title}</AdTitle>
@@ -330,7 +349,7 @@ const ReviewsEmailCapture = ({
       )
       : (
         <EmailForm
-          {...emailFormProps}
+          {...restProps}
           optionalIcon="‣"
           onSubmit={onSubmit}
           howWeUseText="How we use your email"
@@ -351,12 +370,6 @@ ReviewsEmailCapture.propTypes = {
   success: PropTypes.bool,
   successText: PropTypes.string,
   title: PropTypes.string.isRequired,
-};
-
-ReviewsEmailCapture.defaultProps = {
-  success: false,
-  successText: 'Thank you! Get ready for Well-Equipped Cook in your inbox on Wednesdays!',
-  ...EmailForm.defaultProps,
 };
 
 export default ReviewsEmailCapture;

--- a/src/components/Ads/ReviewsAds/ReviewsMarketingHat/index.tsx
+++ b/src/components/Ads/ReviewsAds/ReviewsMarketingHat/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled from 'styled-components';
 
 // grab email for for bottom logic
@@ -73,7 +73,7 @@ const ContentSection = styled.div`
   `}
 `;
 
-const ContentWrapper = styled.div`
+const ContentWrapper = styled.div<{ isAnonymous: boolean }>`
   display: flex;
   flex-direction: column;
 
@@ -267,33 +267,51 @@ const Title = styled.h3`
   `}
 `;
 
+type ReviewsMarketingHatProps = {
+  buttonText: string;
+  description: string;
+  desktopAsset?: string;
+  headline: string;
+  incode: string;
+  /** Input Id used in email form to shift focus on error */
+  inputId: string;
+  /** Remove Email Capture in instances where user is not anon */
+  isAnonymous: boolean;
+  mdc: string;
+  mobileAsset?: string;
+  /** Function that redirects & fires mixpanel w/ corresponding incodes */
+  onSubmit: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  title: string;
+  /** Object used to prevent marketing hat flashing while user is being defined */
+};
+
 const ReviewsMarketingHat = ({
   buttonText,
   description,
-  desktopAsset,
+  desktopAsset = 'ATK Reviews Ads/PansHat_Desktop_3x.jpg',
   headline,
   incode,
   inputId,
   isAnonymous,
   mdc,
-  mobileAsset,
+  mobileAsset = 'ATK Reviews Ads/PansHat_Mobile_3x.jpg',
   onSubmit,
   title,
-}) => (
+}: ReviewsMarketingHatProps): ReactElement => (
   <MarketingHatWrapper className={isAnonymous ? 'anon-user' : ''}>
     <AdImage>
       <source
-        srcSet={getImageUrl(desktopAsset, 'reviewsMarketingHat', 307, 'fit')}
+        srcSet={desktopAsset ? getImageUrl(desktopAsset, 'reviewsMarketingHat', 307, 'fit') : ''}
         media="(min-width: 1136px)"
       />
       <source
-        srcSet={getImageUrl(mobileAsset, 'reviewsMarketingHat', 307, 'fit', 512)}
+        srcSet={mobileAsset ? getImageUrl(mobileAsset, 'reviewsMarketingHat', 307, 'fit', 512) : ''}
         media="(min-width: 768px)"
       />
       <img
         alt=""
         className="marketing-hat__image"
-        src={getImageUrl(mobileAsset, 'reviewsMarketingHat', 267, 'fit', 450)}
+        src={mobileAsset ? getImageUrl(mobileAsset, 'reviewsMarketingHat', 267, 'fit', 450) : ''}
       />
     </AdImage>
     <ContentSection className={isAnonymous ? 'anon-user' : ''}>
@@ -338,11 +356,6 @@ ReviewsMarketingHat.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   /** Object used to prevent marketing hat flashing while user is being defined */
-};
-
-ReviewsMarketingHat.defaultProps = {
-  desktopAsset: 'ATK Reviews Ads/PansHat_Desktop_3x.jpg',
-  mobileAsset: 'ATK Reviews Ads/PansHat_Mobile_3x.jpg',
 };
 
 export default ReviewsMarketingHat;

--- a/src/components/Ads/ShowcaseAds/FreeTrialAd/index.tsx
+++ b/src/components/Ads/ShowcaseAds/FreeTrialAd/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 
 import { getImageUrl } from '../../../../lib/cloudinary';
@@ -135,6 +135,15 @@ const FreeTrialCta = styled.a.attrs({
   className: 'free-trial-ad__cta',
 })`${withThemes(FreeTrialCtaTheme)}`;
 
+type FreeTrialAdProps = {
+  cloudinaryId: string;
+  cta: string;
+  ctaHref: string;
+  onClick: () => void;
+  title: string;
+  subtitle: string;
+};
+
 const FreeTrialAd = ({
   cloudinaryId,
   cta,
@@ -142,7 +151,7 @@ const FreeTrialAd = ({
   onClick,
   subtitle,
   title,
-}) => (
+}: FreeTrialAdProps): ReactElement => (
   <FreeTrialWrapper>
     <FreeTrialPicture>
       <source
@@ -195,10 +204,6 @@ FreeTrialAd.propTypes = {
   onClick: PropTypes.func,
   title: PropTypes.string.isRequired,
   subtitle: PropTypes.string.isRequired,
-};
-
-FreeTrialAd.defaultProps = {
-  onClick: null,
 };
 
 export default FreeTrialAd;

--- a/src/components/Ads/ShowcaseAds/LandingEmailAd/index.tsx
+++ b/src/components/Ads/ShowcaseAds/LandingEmailAd/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 
 import {
@@ -17,7 +17,7 @@ import EmailForm from '../../../Forms/EmailForm';
 import Image from '../../../Cards/shared/Image';
 
 const LandingEmailTheme = {
-  default: css`
+  default: css<{ success: boolean }>`
     align-items: center;
     background-color: ${color.white};
     display: flex;
@@ -87,7 +87,7 @@ const LandingEmailTheme = {
 
 const LandingEmailWrapper = styled.div.attrs({
   className: 'landing-email-ad-wrapper',
-})`${withThemes(LandingEmailTheme)}`;
+})<{ success?: boolean }>`${withThemes(LandingEmailTheme)}`;
 
 const ImageWrapper = styled.div`
   background-size: cover;    
@@ -111,7 +111,7 @@ const ImageWrapper = styled.div`
   }
 `;
 
-const FormColumnWrapper = styled.div`
+const FormColumnWrapper = styled.div<{ success?: boolean }>`
   display: flex;
   justify-content: center;
   margin-bottom: ${({ success }) => (success ? '10%' : '0')};
@@ -121,7 +121,7 @@ const FormColumnWrapper = styled.div`
   `} 
 `;
 
-const FormBodyContent = styled.div`
+const FormBodyContent = styled.div<{ success?: boolean }>`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -234,18 +234,31 @@ const ContentTitle = styled.p.attrs({
   className: 'landing-ad-content-title',
 })`${withThemes(ContentTitleTheme)}`;
 
+type LandingEmailAdProps = {
+  buttonText?: string;
+  desktopImageUrl: string;
+  errorText?: string;
+  inputId: string;
+  headline?: string;
+  onSubmit: (email: string) => void;
+  tabletImageUrl: string;
+  title: string;
+  success?: boolean;
+  successText?: string;
+};
+
 const LandingEmailAd = ({
-  buttonText,
+  buttonText = 'Sign me up',
   desktopImageUrl,
-  errorText,
-  headline,
+  errorText = 'Invalid email address',
+  headline = '',
   inputId,
   onSubmit,
-  success,
-  successText,
+  success = false,
+  successText = 'Thank you! Get ready for watch and cook newsletter in your inbox.',
   tabletImageUrl,
   title,
-}) => (
+}: LandingEmailAdProps): ReactElement => (
   <LandingEmailWrapper success={success}>
     <ImageWrapper>
       <Image
@@ -297,14 +310,6 @@ LandingEmailAd.propTypes = {
   title: PropTypes.string.isRequired,
   success: PropTypes.bool,
   successText: PropTypes.string,
-};
-
-LandingEmailAd.defaultProps = {
-  buttonText: 'Sign me up',
-  errorText: 'Invalid email address',
-  headline: '',
-  success: false,
-  successText: 'Thank you! Get ready for watch and cook newsletter in your inbox.',
 };
 
 export default LandingEmailAd;

--- a/src/components/Ads/ShowcaseAds/MembershipShowcaseAd/index.tsx
+++ b/src/components/Ads/ShowcaseAds/MembershipShowcaseAd/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 
 import Gif from '../../../Gif';
@@ -127,13 +127,21 @@ const deviceIdMap = {
   phone: 'mise-play/membership-showcase-tablet-3',
 };
 
+type MembershipShowcaseAdProps = {
+  cta: string;
+  ctaHref: string;
+  deviceType: 'desktop' | 'phone' | 'tablet';
+  onClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  title: () => ReactNode;
+};
+
 const MembershipShowcaseAd = ({
   cta,
   ctaHref,
   deviceType,
   onClick,
   title,
-}) => (
+}: MembershipShowcaseAdProps): ReactElement => (
   <MembershipShowcase>
     <MembershipShowcaseFigure>
       <Gif
@@ -164,13 +172,9 @@ const MembershipShowcaseAd = ({
 MembershipShowcaseAd.propTypes = {
   cta: PropTypes.string.isRequired,
   ctaHref: PropTypes.string.isRequired,
-  deviceType: PropTypes.oneOf(['desktop', 'phone', 'tablet']).isRequired,
+  deviceType: PropTypes.oneOf(['desktop', 'phone', 'tablet'] as const).isRequired,
   onClick: PropTypes.func,
   title: PropTypes.func.isRequired,
-};
-
-MembershipShowcaseAd.defaultProps = {
-  onClick: null,
 };
 
 export default MembershipShowcaseAd;

--- a/src/components/Ads/ShowcaseAds/SchoolAd/index.tsx
+++ b/src/components/Ads/ShowcaseAds/SchoolAd/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 
 import Gif from '../../../Gif';
@@ -188,6 +188,16 @@ const deviceIdMap = {
   phone: 'mise-play/school-showcase-tablet-3',
 };
 
+type SchoolAdProps = {
+  cta: string;
+  ctaHref: string;
+  ctaTarget?: string;
+  deviceType: 'desktop' | 'phone' | 'tablet';
+  onClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  subtitle: string;
+  title: string;
+};
+
 const SchoolAd = ({
   cta,
   ctaHref,
@@ -196,7 +206,7 @@ const SchoolAd = ({
   onClick,
   subtitle,
   title,
-}) => (
+}: SchoolAdProps): ReactElement => (
   <School>
     <SchoolFigure>
       <Gif
@@ -242,11 +252,6 @@ SchoolAd.propTypes = {
   onClick: PropTypes.func,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-};
-
-SchoolAd.defaultProps = {
-  ctaTarget: null,
-  onClick: null,
 };
 
 export default SchoolAd;

--- a/src/components/Ads/ShowcaseAds/SingleProductShowcaseAd/index.tsx
+++ b/src/components/Ads/ShowcaseAds/SingleProductShowcaseAd/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 
 import Badge from '../../../Badge';
@@ -165,6 +165,17 @@ const ProductCta = styled.a.attrs({
   className: 'product__cta',
 })`${withThemes(ProductCtaTheme)}`;
 
+type SingleProductShowcaseAdProps = {
+  cloudinaryId: string;
+  cta: string;
+  ctaHref: string;
+  ctaTarget?: string;
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  siteKey: 'atk' | 'cio' | 'cco' | 'kids' | 'school' | 'shop';
+  subtitle: string;
+  title: string;
+};
+
 const SingleProductShowcaseAd = ({
   cloudinaryId,
   cta,
@@ -174,7 +185,7 @@ const SingleProductShowcaseAd = ({
   siteKey,
   subtitle,
   title,
-}) => (
+}: SingleProductShowcaseAdProps): ReactElement => (
   <Product>
     <ProductPicture>
       <source
@@ -233,11 +244,6 @@ SingleProductShowcaseAd.propTypes = {
   siteKey: PropTypes.oneOf(['atk', 'cio', 'cco', 'kids', 'school', 'shop']).isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-};
-
-SingleProductShowcaseAd.defaultProps = {
-  ctaTarget: null,
-  onClick: null,
 };
 
 export default SingleProductShowcaseAd;

--- a/src/components/Ads/SingleMembershipAd/index.tsx
+++ b/src/components/Ads/SingleMembershipAd/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 
 import MembershipBenefitIcons from '../components/MembershipBenefitsIcons';
@@ -177,12 +177,19 @@ const SingleMembershipCta = styled.a.attrs({
   className: 'single-membership-ad__cta',
 })`${withThemes(SingleMembershipCtaTheme)}`;
 
+type SingleMembershipAdProps = {
+  cta: string;
+  ctaHref: string;
+  onClick: () => void;
+  title: () => ReactNode;
+};
+
 const SingleMembershipAd = ({
   cta,
   ctaHref,
   onClick,
   title,
-}) => (
+}: SingleMembershipAdProps): ReactElement => (
   <SingleMembership>
     <SingleMembershipInner>
       <SingleMembershipContent>
@@ -207,10 +214,6 @@ SingleMembershipAd.propTypes = {
   ctaHref: PropTypes.string.isRequired,
   onClick: PropTypes.func,
   title: PropTypes.func.isRequired,
-};
-
-SingleMembershipAd.defaultProps = {
-  onClick: null,
 };
 
 export default SingleMembershipAd;

--- a/src/components/Ads/SingleProductAd/index.tsx
+++ b/src/components/Ads/SingleProductAd/index.tsx
@@ -1,6 +1,6 @@
 import breakpoint from 'styled-components-breakpoint';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 
 import { getImageUrl } from '../../../lib/cloudinary';
@@ -146,6 +146,15 @@ const SingleProductCta = styled.a.attrs({
   className: 'single-product-ad__cta',
 })`${withThemes(SingleProductCtaTheme)}`;
 
+type SingleProductAdProps = {
+  cloudinaryId: string;
+  cta: string;
+  ctaHref: string;
+  ctaTarget?: string;
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  title: string;
+};
+
 const SingleProductAd = ({
   cloudinaryId,
   cta,
@@ -153,7 +162,7 @@ const SingleProductAd = ({
   ctaTarget,
   onClick,
   title,
-}) => (
+}: SingleProductAdProps): ReactElement => (
   <SingleProductWrapper>
     <SingleProductInner>
       <SingleProductContent>
@@ -206,11 +215,6 @@ SingleProductAd.propTypes = {
   ctaTarget: PropTypes.string,
   onClick: PropTypes.func,
   title: PropTypes.string.isRequired,
-};
-
-SingleProductAd.defaultProps = {
-  ctaTarget: null,
-  onClick: null,
 };
 
 export default SingleProductAd;

--- a/src/components/Ads/components/MembershipBenefitsIcons.tsx
+++ b/src/components/Ads/components/MembershipBenefitsIcons.tsx
@@ -1,10 +1,22 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { ComponentType, ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 import { Cookbook, Phone, RecipeCard, RibbonAward, Videos } from '../../DesignTokens/Icon/svgs';
 import { color, font, withThemes } from '../../../styles';
 
-const benefits = [
+const icons = {
+  card: RecipeCard,
+  cookbook: Cookbook,
+  watch: Videos,
+  ratings: RibbonAward,
+  mobile: Phone,
+} as const;
+
+type IconKeys = keyof typeof icons;
+
+type BenefitShape = { icon: IconKeys, desc: string };
+
+const benefits: BenefitShape[] = [
   {
     icon: 'card',
     desc: '12,000 + recipes',
@@ -34,21 +46,13 @@ const MembershipBenefitsIconsWrapper = styled.div.attrs({
   justify-content: space-between;
 `;
 
-const icons = {
-  card: RecipeCard,
-  cookbook: Cookbook,
-  watch: Videos,
-  ratings: RibbonAward,
-  mobile: Phone,
-};
-
-const renderIcon = (icon) => {
-  const Icon = icon ? icons[icon] : null;
+const renderIcon = (icon?: keyof typeof icons) => {
+  const Icon = (icon ? icons[icon] : null) as ComponentType<{ fill: string }>;
   return <Icon fill={color.white} />;
 };
 
 const BenefitTheme = {
-  default: css`
+  default: css<{ animated: boolean }>`
     align-items: center;
     display: flex;
     flex-direction: column;
@@ -89,7 +93,7 @@ const BenefitTheme = {
   `,
 };
 
-const Benefit = styled.div`
+const Benefit = styled.div<{ animated?: boolean }>`
   ${withThemes(BenefitTheme)}
 `;
 
@@ -129,7 +133,13 @@ const CircularIcon = styled.div`
   ${withThemes(CircularIconTheme)}
 `;
 
-const MembershipBenefitsIcons = ({ animated }) => (
+type MembershipBenefitsIconsProps = {
+  animated?: boolean;
+};
+
+const MembershipBenefitsIcons = ({
+  animated = true,
+}: MembershipBenefitsIconsProps): ReactElement => (
   <MembershipBenefitsIconsWrapper
     data-testid="benefit-icons"
   >
@@ -153,12 +163,9 @@ const MembershipBenefitsIcons = ({ animated }) => (
   </MembershipBenefitsIconsWrapper>
 );
 
+// TODO: remove when fully typescript
 MembershipBenefitsIcons.propTypes = {
   animated: PropTypes.bool,
-};
-
-MembershipBenefitsIcons.defaultProps = {
-  animated: true,
 };
 
 export default MembershipBenefitsIcons;

--- a/src/components/AudioPlayer/index.tsx
+++ b/src/components/AudioPlayer/index.tsx
@@ -1,5 +1,5 @@
 import breakpoint from 'styled-components-breakpoint';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import plyrStyles from './plyrStyles';
@@ -155,16 +155,31 @@ display: none;
 
 const plyrOptions = { controls: ['progress', 'current-time', 'duration'], invertTime: false, displayDuration: true };
 
+type AudioPlayerProps = {
+  /** id of the episode */
+  id: string;
+  /** title of the episode */
+  title: string;
+  /** episode number */
+  episode?: number;
+  /** link to page with more episode details */
+  href?: string;
+  imageAlt?: string;
+  imageUrl?: string;
+};
+
 const AudioPlayer = ({
   id,
   title,
   episode,
-  imageAlt,
-  imageUrl,
-  href,
-}) => {
-  const playerEl = useRef(null);
-  const playerInstance = useRef(null);
+  imageAlt = '',
+  imageUrl = '',
+  href = '',
+}: AudioPlayerProps): ReactElement => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const playerEl = useRef<any>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const playerInstance = useRef<Record<string, any> | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
 
   // update player information when a new episode is selected
@@ -278,8 +293,8 @@ const AudioPlayer = ({
       <LinkWrapper className="player__more-info">
         <div className="player__image">
           <Image
-            imageAlt={imageAlt}
-            imageUrl={imageUrl}
+            imageAlt={imageAlt ?? ''}
+            imageUrl={imageUrl ?? ''}
           />
         </div>
         {
@@ -301,13 +316,6 @@ AudioPlayer.propTypes = {
   href: PropTypes.string,
   imageAlt: PropTypes.string,
   imageUrl: PropTypes.string,
-};
-
-AudioPlayer.defaultProps = {
-  episode: null,
-  href: '',
-  imageAlt: '',
-  imageUrl: '',
 };
 
 export default React.memo(AudioPlayer);

--- a/src/components/Buttons/Button/index.tsx
+++ b/src/components/Buttons/Button/index.tsx
@@ -48,7 +48,7 @@ function Button({
   onClick,
   type,
   ...restProps
-}: React.ComponentPropsWithoutRef<"button">) {
+}: React.ComponentPropsWithoutRef<'button'>) {
   return (
     <StyledButton
       className={className}
@@ -66,12 +66,6 @@ Button.propTypes = {
   children: PropTypes.node.isRequired,
   onClick: PropTypes.func,
   type: PropTypes.oneOf(['submit', 'reset', 'button']),
-};
-
-Button.defaultProps = {
-  className: '',
-  onClick: () => {},
-  type: 'button',
 };
 
 export default Button;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,27 @@
+/** quick blackbox typing for 'styled-components-breakpoint'  */
+type ThemeBreakpoint = 'xs' | 'sm' | 'smmd' | 'md' | 'lg' | 'xlg';
+declare module 'styled-components-breakpoint' {
+    type StyledComponentsInterpolation =
+        | ((
+            /** TODO: should infer context from styled components */
+            executionContext: Record<string, unknown>) => StyledComponentsInterpolation)
+        | string
+        | number
+        | StyledComponentsInterpolation[];
+
+    function templateFunction(
+        strings: TemplateStringsArray,
+        ...interpolations: StyledComponentsInterpolation[]): string;
+    /** theme breakpoints defined in 'src/styles/breakpoints' */
+    function styledBreakpoint(gte: ThemeBreakpoint, lt?: ThemeBreakpoint): typeof templateFunction;
+    export default styledBreakpoint;
+}
+
+/** dry type placeholder */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const dry: any;
+
+declare class Plyr {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(...args: any);
+}

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -92,6 +92,6 @@ const color = {
   caramel: '#6E562A',
   deepPlumb: '#3E285C',
   doveGray: '#6e6e6e',
-};
+} as const;
 
 export default color;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "esnext",
     "moduleResolution": "node",
     "strict": true,
+    "noImplicitAny": true,
     "esModuleInterop": true,
     "allowJs": true,
     "jsx": "react",


### PR DESCRIPTION
I put some notes down that may be helpful. There's likely a lot of explanation missing or not necessary so I could use some feedback on what to add or remove.

Had these changes already going, so I will focus on cards, carousels, image next as discussed.

React.FC is not recommended by official sources, typing props and component is updated in docs. There are tradeoffs you want to remember. Some lint definitions rely on React.FC to enforce certain rules, some transforms like ones that convert typescript types to prop types for additional JS library support seem to also require explicitly defining a function as a react components. Anything that needs a solid identifier of a react functional component you should be suspect of this issue.

defaultProps is deprecated on functional components only. There's an issue with InferProps that would affect our ability to use es6 default parameters. I talked it over with Alex, and it seems best to use Typescript types directly on props instead of inferring them through prop types. We can leave the prop types there for js consumers like espresso and jarvis until espresso is migrated to typescript. (jarvis has very little usage that shouldn't be a concern) There's seems to be some legacy in InferProps from flow that allows non required values to be null. This causes issues with defaultProps, as well as es6 default parameters, since defaults would need to be checked twice or with iconSize ??= 'default' in the body instead of the default parameters.