### PR TITLE
Differiate links from amazon in screen reader

### DIFF
--- a/src/components/Cards/ReviewableSummaryCard/index.js
+++ b/src/components/Cards/ReviewableSummaryCard/index.js
@@ -287,6 +287,7 @@ const ReviewableSummaryCard = React.memo(({
                 'data-price': price || '',
                 'data-recommendation-status': recommendationStatus,
                 'data-reviewable': name,
+                'aria-label': `Buy ${name} now`,
               }}
               text={displayPrice && price ? `Buy for ${price}` : 'Buy Now'}
               icon={buyNowIcon}


### PR DESCRIPTION
Solution approved by Jason to add the `Buy {product-name} now` for screen reader