### PR TITLE
ARCHIE 3168: Photo Carousel mise-ui

### DIFF
--- a/src/components/Carousels/PhotoCarousel/PhotoCarousel.stories.tsx
+++ b/src/components/Carousels/PhotoCarousel/PhotoCarousel.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 import PhotoCarousel, { PhotoCarouselProps } from './PhotoCarousel';
-import { defaultTheme, setBackground, storybookParameters, wrapKnobs } from '../../../config/shared.stories';
+import { defaultTheme, setBackground, setViewport, storybookParameters, wrapKnobs } from '../../../config/shared.stories';
 
 export default {
   title: 'Components/Carousels/PhotoCarousel',
@@ -61,3 +61,9 @@ const Container = styled.div`
 `;
 
 export const AtkPhotoCarouselInContainer = () => <Container><PreviewPhotoCarousel theme={{ siteKey: 'atk' }} /></Container>;
+
+export const TabletPhotoCarousel = () => <PreviewPhotoCarousel theme={{ siteKey: 'atk' }} />;
+setViewport('ipad', TabletPhotoCarousel);
+
+export const MobilePhotoCarousel = () => <PreviewPhotoCarousel theme={{ siteKey: 'atk' }} />;
+setViewport('iphone6', MobilePhotoCarousel);

--- a/src/components/Carousels/PhotoCarousel/PhotoCarousel.tsx
+++ b/src/components/Carousels/PhotoCarousel/PhotoCarousel.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from 'react';
 import styled, { css } from 'styled-components';
 import cloudinaryInstance, { baseImageConfig } from '../../../lib/cloudinary';
 import { withThemes, color, font } from '../../../styles';
+import { cssThemedColor, cssThemedFont } from '../../../styles/mixins';
 import Carousel from '../Carousel';
 
 export type PhotoCarouselCellProps = {
@@ -57,12 +58,12 @@ const Wrapper = styled.div<{ maxWidth: string }>`
     overflow: hidden;
   }
   .carousel-cell {
-    width: 95%;
+    width: 100%;
     margin-right: 5%;
   }
   .flickity-button {
     background: ${color.gray20};
-    /* display: block; // uncomment to show flickity buttons in all viewports */
+    display: block;
   }
   .flickity-button:hover {
     background: ${color.nobel};
@@ -157,14 +158,10 @@ const Title = styled.div`
   margin: 12px 0;
   font-size: 26px;
   line-height: 1.15;
-  color: ${color.black};
-
-  ${withThemes({
-    default: css`font-family: ${font.pnb};`,
-    atk: css`font-family: ${font.pnb};`,
-    cco: css`font-family: ${font.clb};`,
-    cio: css`font-family: ${font.mwr};`,
-  })}
+  // depends on .flickity-prev-next-button.previous
+  padding-right: calc(5% + 72px);
+  ${cssThemedColor}
+  ${cssThemedFont}
 `;
 
 /** Composable component API or references for styled components classNames. */


### PR DESCRIPTION
ARCHIE-3168: add themed font/color to title. Override hiding arrow buttons. carousel slide to 100% width.
MobileViewports added in storybook. 