### PR TITLE
ARCHIE-2678: creating Menu instant search component, theming other instant search components for cco and cio

### DIFF
--- a/src/components/Algolia/shared/ClearRefinements/ClearRefinements.stories.js
+++ b/src/components/Algolia/shared/ClearRefinements/ClearRefinements.stories.js
@@ -1,35 +1,33 @@
 import React from 'react';
-import styled from 'styled-components';
 
 import LabelFrame from '../../../LabelFrame';
-import CurrentRefinements from '../CurrentRefinements';
 import ClearRefinements from './index';
-import SearchRefinementList from '../../search/SearchRefinementList';
 import MiseInstantSearch from '../../../../lib/algolia/MiseInstantSearch/MiseInstantSearch';
+import SearchRefinementList from '../../search/SearchRefinementList';
+import { siteKey } from '../../../../config/argTypes';
+import { addThemedWrapper } from '../../../../config/decorators';
 
 export default {
   title: 'Components/Algolia/shared/ClearRefinements',
   component: ClearRefinements,
+  decorators: [ addThemedWrapper() ],
+  argTypes: { siteKey },
 };
 
-const StyledWrapper = styled.div`
-  margin-bottom: 2.4rem;
-`;
-
-export const Default = () => (
+const Template = (args) => (
   <MiseInstantSearch>
     <LabelFrame label="Component">
       <ClearRefinements />
     </LabelFrame>
-    <LabelFrame label="Supplemental Components">
-      <StyledWrapper>
-        <CurrentRefinements />
-      </StyledWrapper>
+    <LabelFrame label="Supplemental Component">
       <SearchRefinementList
-        attribute="search_cuisine_list"
-        operator="and"
-        showHideLabel="CUISINE"
+        attribute="search_review_type_list"
+        operator="or"
+        showHideLabel="Equipment"
       />
     </LabelFrame>
   </MiseInstantSearch>
 );
+
+export const Default = Template.bind({});
+Default.args = { siteKey: 'atk' };

--- a/src/components/Algolia/shared/ClearRefinements/index.js
+++ b/src/components/Algolia/shared/ClearRefinements/index.js
@@ -7,16 +7,34 @@ import { color, font, fontSize, lineHeight, spacing, withThemes } from '../../..
 
 const StyledClearRefinementsTheme = {
   default: css`
-    color: ${color.eclipse};
     font: ${fontSize.md}/${lineHeight.sm} ${font.pnr};
     margin-bottom: ${spacing.xsm};
 
     &[disabled] {
       display: none;
     }
+  `,
+  atk: css`
+    color: ${color.eclipse};
 
     &:hover {
       color: ${color.mint};
+      cursor: pointer;
+    }
+  `,
+  cco: css`
+    color: ${color.black};
+
+    &:hover {
+      color: ${color.denim};
+      cursor: pointer;
+    }
+  `,
+  cio: css`
+    color: ${color.cork};
+
+    &:hover {
+      color: ${color.squirrel};
       cursor: pointer;
     }
   `,

--- a/src/components/Algolia/shared/CurrentRefinements/CurrentRefinements.stories.js
+++ b/src/components/Algolia/shared/CurrentRefinements/CurrentRefinements.stories.js
@@ -2,25 +2,32 @@ import React from 'react';
 
 import LabelFrame from '../../../LabelFrame';
 import CurrentRefinements from './index';
-import SearchRefinementList from '../../search/SearchRefinementList';
 import MiseInstantSearch from '../../../../lib/algolia/MiseInstantSearch/MiseInstantSearch';
+import SearchRefinementList from '../../search/SearchRefinementList';
+import { siteKey } from '../../../../config/argTypes';
+import { addThemedWrapper } from '../../../../config/decorators';
 
 export default {
   title: 'Components/Algolia/shared/CurrentRefinements',
   component: CurrentRefinements,
+  decorators: [ addThemedWrapper() ],
+  argTypes: { siteKey },
 };
 
-export const Default = () => (
+const Template = (args) => (
   <MiseInstantSearch>
     <LabelFrame label="Component">
       <CurrentRefinements />
     </LabelFrame>
     <LabelFrame label="Supplemental Component">
       <SearchRefinementList
-        attribute="search_cuisine_list"
-        operator="and"
-        showHideLabel="CUISINE"
+        attribute="search_review_type_list"
+        operator="or"
+        showHideLabel="Equipment"
       />
     </LabelFrame>
   </MiseInstantSearch>
 );
+
+export const Default = Template.bind({});
+Default.args = { siteKey: 'atk' };

--- a/src/components/Algolia/shared/CurrentRefinements/index.js
+++ b/src/components/Algolia/shared/CurrentRefinements/index.js
@@ -21,7 +21,8 @@ const RefinementTheme = {
     & > button {
       pointer-events: auto;
     }
-
+  `,
+  atk: css`
     /* Change color of p child to mint when hovered. */
     &:hover > p {
       color: ${color.mint}
@@ -31,6 +32,32 @@ const RefinementTheme = {
     &:hover > button:hover {
       svg g {
         stroke: ${color.mint};
+      }
+    }
+  `,
+  cco: css`
+    /* Change color of p child to mint when hovered. */
+    &:hover > p {
+      color: ${color.denim}
+    }
+
+    /* Change svg stroke color when parent and 'x' button child are hovered. */
+    &:hover > button:hover {
+      svg g {
+        stroke: ${color.denim};
+      }
+    }
+  `,
+  cio: css`
+    /* Change color of p child to mint when hovered. */
+    &:hover > p {
+      color: ${color.squirrel}
+    }
+
+    /* Change svg stroke color when parent and 'x' button child are hovered. */
+    &:hover > button:hover {
+      svg g {
+        stroke: ${color.squirrel};
       }
     }
   `,
@@ -61,8 +88,16 @@ const Refinement = styled.div`
 const RefinementLabelTheme = {
   default: css`
     font: ${fontSize.md}/${lineHeight.sm} ${font.pnr};
-    color: ${color.eclipse};
     margin-right: ${spacing.xsm};
+  `,
+  atk: css`
+    color: ${color.eclipse};
+  `,
+  cco: css`
+    color: ${color.black};
+  `,
+  cio: css`
+    color: ${color.cork};
   `,
   kidsSearch: css`
     color: ${color.black};
@@ -81,11 +116,25 @@ const RefinementLabel = styled.p`
 const RefinementClearButtonTheme = {
   default: css`
     font: ${fontSize.md}/${lineHeight.sm} ${font.pnr};
-    color: ${color.nobel};
     width: 0.8rem;
 
     svg {
       height: 0.8rem;
+    }
+  `,
+  atk: css`
+    svg g {
+      stroke: ${color.eclipse};
+    }
+  `,
+  cco: css`
+    svg g {
+      stroke: ${color.black};
+    }
+  `,
+  cio: css`
+    svg g {
+      stroke: ${color.cork};
     }
   `,
   kidsSearch: css`

--- a/src/components/Algolia/shared/Menu/Menu.stories.js
+++ b/src/components/Algolia/shared/Menu/Menu.stories.js
@@ -2,13 +2,13 @@ import React from 'react';
 
 import LabelFrame from '../../../LabelFrame';
 import MiseInstantSearch from '../../../../lib/algolia/MiseInstantSearch/MiseInstantSearch';
-import ToggleRefinement from './index';
+import Menu from './index';
 import { siteKey } from '../../../../config/argTypes';
 import { addThemedWrapper } from '../../../../config/decorators';
 
 export default {
-  title: 'Components/Algolia/shared/ToggleRefinement',
-  component: ToggleRefinement,
+  title: 'Components/Algolia/shared/Menu',
+  component: Menu,
   decorators: [ addThemedWrapper() ],
   argTypes: { siteKey },
 };
@@ -16,15 +16,10 @@ export default {
 const Template = (args) => (
   <MiseInstantSearch>
     <LabelFrame label="Component">
-      <ToggleRefinement
-        attribute="search_document_klass"
-        label="Equipment Reivew"
-        value="equipment_review"
-        {...args}
-      />
+      <Menu attribute="search_review_type_list" />
     </LabelFrame>
   </MiseInstantSearch>
 );
 
-export const Trending = Template.bind({});
-Trending.args = {siteKey: 'atk' };
+export const Default = Template.bind({});
+Default.args = { siteKey: 'atk' };

--- a/src/components/Algolia/shared/Menu/index.js
+++ b/src/components/Algolia/shared/Menu/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { connectMenu } from 'react-instantsearch-dom';
+
+import RefinementFilter from '../RefinementFilter2';
+
+const MenuWrapper = styled.ul`
+  .refinement-filter__wrapper {
+    margin-bottom: 1.2rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+`;
+
+const Menu = ({ items, ...restProps }) => (
+  <MenuWrapper>
+    {
+      items.map(item => (
+        <RefinementFilter
+          {...item}
+          {...restProps}
+          includeCount={false}
+        />
+      ))
+    }
+  </MenuWrapper>
+);
+
+Menu.propTypes = {
+  items: PropTypes.array.isRequired,
+};
+
+export default connectMenu(Menu);

--- a/src/components/Algolia/shared/RefinementFilter2/index.js
+++ b/src/components/Algolia/shared/RefinementFilter2/index.js
@@ -5,40 +5,73 @@ import styled, { css } from 'styled-components';
 import { Checkmark } from '../../../DesignTokens/Icon/svgs';
 import { color, font, fontSize, spacing, withThemes } from '../../../../styles';
 
-const RefinementFilterWrapper = styled.div`
-  align-items: center;
-  display: flex;
+const RefinementFilterWrapperTheme = {
+  default: css`
+    align-items: center;
+    display: flex;
 
-  &:focus-within {
-    box-shadow: 0 0 0 2px ${color.focusRing};
-  }
-
-  &:hover {
-    cursor: pointer;
-
-    .search-refinement-list__label {
-      color: ${color.mint};
+    &:focus-within {
+      box-shadow: 0 0 0 2px ${color.focusRing};
     }
-  }
+
+    &:hover {
+      cursor: pointer;
+    }
+  `,
+  atk: css`
+    &:hover {
+      .search-refinement-list__label {
+        color: ${color.mint};
+      }
+    }
+  `,
+  cco: css`
+    &:hover {
+      .search-refinement-list__label {
+        color: ${color.denim};
+      }
+    }
+  `,
+  cio: css`
+    &:hover {
+      .search-refinement-list__label {
+        color: ${color.squirrel};
+      }
+    }
+  `,
+};
+
+const RefinementFilterWrapper = styled.div`
+  ${withThemes(RefinementFilterWrapperTheme)}
 `;
 
 const RefinementFilterLabelTheme = {
   default: css`
     color: ${color.eclipse};
     font: ${fontSize.md}/1.38 ${font.pnr};
-
+    ${({ isRefined }) => (isRefined ? `font: ${fontSize.md}/1.38 ${font.pnb};` : '')}
+  `,
+  atk: css`
     &:hover {
       color: ${color.mint};
       cursor: pointer;
     }
-
-    ${({ isRefined }) => (isRefined ? `color: ${color.mint}; font: ${fontSize.md}/1.38 ${font.pnb};` : '')}
   `,
   cco: css`
     color: ${color.black};
+
+    &:hover {
+      color: ${color.denim};
+      cursor: pointer;
+    }
   `,
   cio: css`
     color: ${color.cork};
+
+    &:hover {
+      color: ${color.squirrel};
+      cursor: pointer;
+    }
   `,
 };
 

--- a/src/components/Algolia/shared/ResultsCount/ResultsCount.stories.js
+++ b/src/components/Algolia/shared/ResultsCount/ResultsCount.stories.js
@@ -1,18 +1,25 @@
 import React from 'react';
 
 import LabelFrame from '../../../LabelFrame';
-import ResultsCount from './index';
 import MiseInstantSearch from '../../../../lib/algolia/MiseInstantSearch/MiseInstantSearch';
+import ResultsCount from './index';
+import { siteKey } from '../../../../config/argTypes';
+import { addThemedWrapper } from '../../../../config/decorators';
 
 export default {
   title: 'Components/Algolia/shared/ResultsCount',
   component: ResultsCount,
+  decorators: [ addThemedWrapper() ],
+  argTypes: { siteKey },
 };
 
-export const Default = () => (
+const Template = (args) => (
   <MiseInstantSearch>
     <LabelFrame label="Component">
       <ResultsCount />
     </LabelFrame>
   </MiseInstantSearch>
 );
+
+export const Default = Template.bind({});
+Default.args = { siteKey: 'atk' };

--- a/src/components/Algolia/shared/ResultsCount/index.js
+++ b/src/components/Algolia/shared/ResultsCount/index.js
@@ -15,13 +15,21 @@ import {
 
 const StatsWrapperTheme = {
   default: css`
-    color: ${color.eclipse};
     font: ${fontSize.md}/${lineHeight.sm} ${font.pnb};
     margin-bottom: ${spacing.xsm};
 
     ${breakpoint('md')`
       float: left;
     `}
+  `,
+  atk: css`
+    color: ${color.eclipse};
+  `,
+  cco: css`
+    color: ${color.black};
+  `,
+  cio: css`
+    color: ${color.cork};
   `,
   kidsSearch: css`
     color: ${color.black};

--- a/src/components/Algolia/shared/SortBy/SortBy.stories.js
+++ b/src/components/Algolia/shared/SortBy/SortBy.stories.js
@@ -3,45 +3,47 @@ import React from 'react';
 import LabelFrame from '../../../LabelFrame';
 import MiseInstantSearch from '../../../../lib/algolia/MiseInstantSearch/MiseInstantSearch';
 import SortBy from './index';
+import { siteKey } from '../../../../config/argTypes';
+import { addThemedWrapper } from '../../../../config/decorators';
 
 export default {
   title: 'Components/Algolia/shared/SortBy',
   component: SortBy,
+  decorators: [ addThemedWrapper() ],
+  argTypes: { siteKey },
 };
+
 const items = [
   { value: 'everest_search_development', label: 'Relevance' },
   { value: 'everest_search_popularity_desc_development', label: 'Popularity' },
   { value: 'everest_search_published_date_desc_development', label: 'Publish Date' },
 ];
-export const Relevance = () => (
+
+const Template = (args) => (
   <MiseInstantSearch>
     <LabelFrame label="Component">
       <SortBy
-        defaultRefinement="everest_search_development"
         items={items}
+        {...args}
       />
     </LabelFrame>
   </MiseInstantSearch>
 );
 
-export const Popularity = () => (
-  <MiseInstantSearch>
-    <LabelFrame label="Component">
-      <SortBy
-        defaultRefinement="everest_search_popularity_desc_development"
-        items={items}
-      />
-    </LabelFrame>
-  </MiseInstantSearch>
-);
+export const Relevance = Template.bind({});
+Relevance.args = {
+  defaultRefinement: items[0].value,
+  siteKey: 'atk',
+};
 
-export const PublishDate = () => (
-  <MiseInstantSearch>
-    <LabelFrame label="Component">
-      <SortBy
-        defaultRefinement="everest_search_published_date_desc_development"
-        items={items}
-      />
-    </LabelFrame>
-  </MiseInstantSearch>
-);
+export const Popularity = Template.bind({});
+Popularity.args = {
+  defaultRefinement: items[1].value,
+  siteKey: 'atk',
+};
+
+export const PublishDate = Template.bind({});
+PublishDate.args = {
+  defaultRefinement: items[2].value,
+  siteKey: 'atk',
+};

--- a/src/components/Algolia/shared/SortBy/index.js
+++ b/src/components/Algolia/shared/SortBy/index.js
@@ -20,22 +20,48 @@ const SearchSortByItemTheme = {
     margin: ${spacing.xxsm} 0.25rem ${spacing.xsm} -${spacing.xxsm};
     padding-left: ${spacing.xxsm};
 
+    &:focus-within {
+      ${mixins.focusIndicator()};
+      outline-offset: 0;
+    }
+  `,
+  atk: css`
     &:hover {
       cursor: pointer;
 
       .search-sort-by__circle {
         background-color: ${color.mint};
-        border-color: ${color.mint};
       }
 
       .search-sort-by__label {
         color: ${color.mint};
       }
     }
+  `,
+  cco: css`
+    &:hover {
+      cursor: pointer;
 
-    &:focus-within {
-      ${mixins.focusIndicator()};
-      outline-offset: 0;
+      .search-sort-by__circle {
+        background-color: ${color.denim};
+      }
+
+      .search-sort-by__label {
+        color: ${color.denim};
+      }
+    }
+  `,
+  cio: css`
+    &:hover {
+      cursor: pointer;
+
+      .search-sort-by__circle {
+        background-color: ${color.squirrel};
+      }
+
+      .search-sort-by__label {
+        color: ${color.squirrel};
+      }
     }
   `,
   kidsSearch: css`
@@ -81,17 +107,37 @@ const SearchSortByRadioInput = styled.input`
 
 const SearchSortByCircleTheme = {
   default: css`
-    ${({ isRefined }) => (isRefined ? `
-        background-color: ${color.mint};
-        border: solid 1px ${color.mint};
-    ` : `
-        background-color: transparent;
-        border: solid 1px ${color.nobel};
-    `)}
     border-radius: 1.2rem;
     height: 1.2rem;
     margin-right: 0.6rem;
     width: 1.2rem;
+  `,
+  atk: css`
+    border: solid 1px ${color.nobel};
+
+    ${({ isRefined }) => (isRefined ? `
+        background-color: ${color.mint};
+    ` : `
+        background-color: transparent;
+    `)}
+  `,
+  cco: css`
+    border: solid 1px ${color.black};
+
+    ${({ isRefined }) => (isRefined ? `
+        background-color: ${color.denim};
+    ` : `
+        background-color: transparent;
+    `)}
+  `,
+  cio: css`
+    border: solid 1px #D3C5A0;
+
+    ${({ isRefined }) => (isRefined ? `
+        background-color: ${color.squirrel};
+    ` : `
+        background-color: transparent;
+    `)}
   `,
   kidsSearch: css`
     display: none;
@@ -106,7 +152,6 @@ const SearchSortByLabelTheme = {
   default: css`
     align-items: center;
     border: 1px dashed transparent;
-    color: ${color.eclipse};
     display: flex;
     font: ${fontSize.md}/1.38 ${font.pnr};
     font-size: ${fontSize.md};
@@ -115,6 +160,15 @@ const SearchSortByLabelTheme = {
     &:hover {
       cursor: pointer;
     }
+  `,
+  atk: css`
+    color: ${color.eclipse};
+  `,
+  cco: css`
+    color: ${color.black};
+  `,
+  cio: css`
+    color: ${color.cork};
   `,
   kidsSearch: css`
     background-color: ${color.greySmoke};

--- a/src/components/Algolia/shared/ToggleRefinementMenu/ToggleRefinementMenu.stories.js
+++ b/src/components/Algolia/shared/ToggleRefinementMenu/ToggleRefinementMenu.stories.js
@@ -2,13 +2,13 @@ import React from 'react';
 
 import LabelFrame from '../../../LabelFrame';
 import MiseInstantSearch from '../../../../lib/algolia/MiseInstantSearch/MiseInstantSearch';
-import ToggleRefinement from './index';
+import ToggleRefinementMenu from './index';
 import { siteKey } from '../../../../config/argTypes';
 import { addThemedWrapper } from '../../../../config/decorators';
 
 export default {
-  title: 'Components/Algolia/shared/ToggleRefinement',
-  component: ToggleRefinement,
+  title: 'Components/Algolia/shared/ToggleRefinementMenu',
+  component: ToggleRefinementMenu,
   decorators: [ addThemedWrapper() ],
   argTypes: { siteKey },
 };
@@ -16,15 +16,16 @@ export default {
 const Template = (args) => (
   <MiseInstantSearch>
     <LabelFrame label="Component">
-      <ToggleRefinement
-        attribute="search_document_klass"
-        label="Equipment Reivew"
-        value="equipment_review"
+      <ToggleRefinementMenu
+        menuAttribute="search_review_type_list"
+        toggleRefinementAttribute="search_document_klass"
+        toggleRefinementLabel="Equipment Reivews"
+        toggleRefinementValue="equipment_review"
         {...args}
       />
     </LabelFrame>
   </MiseInstantSearch>
 );
 
-export const Trending = Template.bind({});
-Trending.args = {siteKey: 'atk' };
+export const EquipmentReview = Template.bind({});
+EquipmentReview.args = { siteKey: 'atk' };

--- a/src/components/Algolia/shared/ToggleRefinementMenu/index.js
+++ b/src/components/Algolia/shared/ToggleRefinementMenu/index.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import Menu from '../Menu';
+import ToggleRefinement from '../ToggleRefinement';
+
+const ToggleRefinementMenuWrapper = styled.div`
+  .toggle-refinement {
+    margin-bottom: 1.2rem;
+  }
+`;
+
+const ToggleRefinementMenu = ({
+  menuAttribute,
+  toggleRefinementAttribute,
+  toggleRefinementLabel,
+  toggleRefinementValue,
+}) => (
+  <ToggleRefinementMenuWrapper>
+    <ToggleRefinement
+      attribute={toggleRefinementAttribute}
+      label={toggleRefinementLabel}
+      value={toggleRefinementValue}
+    />
+    <Menu attribute={menuAttribute} />
+  </ToggleRefinementMenuWrapper>
+);
+
+ToggleRefinementMenu.propTypes = {
+  menuAttribute: PropTypes.string.isRequired,
+  toggleRefinementAttribute: PropTypes.string.isRequired,
+  toggleRefinementLabel: PropTypes.string.isRequired,
+  toggleRefinementValue: PropTypes.string.isRequired,
+};
+
+export default ToggleRefinementMenu;


### PR DESCRIPTION
* Created new Menu component. This component connects to the instant search component described [here](https://www.algolia.com/doc/api-reference/widgets/menu/react/).
* Added site themes to existing instant search components that will be pulled into the mise extension work.