### PR TITLE
hs articles r5

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "test": "jest",
     "lint": "./node_modules/.bin/eslint .",
     "eject": "react-scripts eject",
-    "storybook": "start-storybook -p 9009 -s public",
-    "build-storybook": "build-storybook -s public",
+    "storybook": "start-storybook -p 9009",
+    "build-storybook": "build-storybook",
     "release": "auto shipit",
     "tsc": "tsc"
   },

--- a/src/components/Articles/ArticleTextBlock/index.js
+++ b/src/components/Articles/ArticleTextBlock/index.js
@@ -206,6 +206,7 @@ const generateImageElAndPosition = (photo) => {
 };
 
 const ArticleTextBlock = ({
+  as,
   content,
   displayOption,
   dropCap,
@@ -227,7 +228,7 @@ const ArticleTextBlock = ({
     >
       {
         title && (
-          <ArticleTextBlockHeading className="article-text-block__heading">
+          <ArticleTextBlockHeading className="article-text-block__heading" as={as}>
             {title}
           </ArticleTextBlockHeading>
         )
@@ -249,6 +250,8 @@ const ArticleTextBlock = ({
 };
 
 ArticleTextBlock.propTypes = {
+  /** styled-components as prop on heading, defaults h3 */
+  as: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
   /** Text content */
   content: PropTypes.string.isRequired,
   /** Default: no extra styles, box: wrap TextBlock in padded box */
@@ -274,6 +277,7 @@ ArticleTextBlock.propTypes = {
 };
 
 ArticleTextBlock.defaultProps = {
+  as: 'h3',
   displayOption: 'default',
   dropCap: false,
   includeInTOC: null,

--- a/src/components/Carousels/PhotoCarousel/PhotoCarousel.tsx
+++ b/src/components/Carousels/PhotoCarousel/PhotoCarousel.tsx
@@ -75,6 +75,10 @@ const Wrapper = styled.div<{ maxWidth: string }>`
     cco: css`background: ${color.black};`,
     cio: css`background: ${color.cork};`,
   })}
+    svg {
+      opacity: 1 !important;
+      transform: scale(1.0) !important;
+    }
   }
   .flickity-prev-next-button {
     width: 25px;

--- a/src/components/MediaEmbed/MediaEmbed.stories.tsx
+++ b/src/components/MediaEmbed/MediaEmbed.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import { setViewport, storybookParameters } from '../../config/shared.stories';
-import MediaEmbed, { InstagramEmbedCloned, TikTokEmbed, YoutubeEmbed, ZypeEmbed } from './MediaEmbed';
+import MediaEmbed, { TikTokEmbed, YoutubeEmbed, ZypeEmbed } from './MediaEmbed';
+import { InstagramEmbed } from '.';
 
 export default {
   title: 'Components/MediaEmbed',
@@ -16,28 +17,54 @@ const instagramUrl = 'https://www.instagram.com/p/CXM58mVgJF0/';
 const stackblitzUrl = 'https://stackblitz.com/edit/react?embed=1&file=src/App.js';
 const zypeVideoId = '5b400b9f4b32992a310627f6';
 
+const longCaptionText = 'Both our winning products had simple ingredient lists with a noticeable lack of additives, such as food colorings and preservatives. In contrast, our least favorite sticks had a slew of additives, including titanium dioxide, a food coloring that is no longer considered safe for consumption by the European Food Safety Authority.';
+
 export const TikTok: ComponentStory<typeof TikTokEmbed> = () => <TikTokEmbed source={tiktokUrl} />;
 TikTok.storyName = 'TikTok';
+
+export const TikTokWithCaption: ComponentStory<typeof TikTokEmbed> = () => (
+  <TikTokEmbed source={tiktokUrl} caption={longCaptionText} />
+);
+TikTokWithCaption.storyName = 'TikTok With Caption';
 
 export const YouTube: ComponentStory<typeof YoutubeEmbed> = () => (
   <YoutubeEmbed source={youtubeUrl} />
 );
 YouTube.storyName = 'YouTube';
 
+export const YouTubeWithCaption: ComponentStory<typeof YoutubeEmbed> = () => (
+  <YoutubeEmbed source={youtubeUrl} caption={longCaptionText} />
+);
+YouTubeWithCaption.storyName = 'YouTube With Caption';
+
 export const Zype = () => <ZypeEmbed source={zypeVideoId} token={process.env.ZYPE_CLIENT_TOKEN ?? ''} />;
+export const ZypeWithCaption = () => <ZypeEmbed source={zypeVideoId} caption={longCaptionText} token={process.env.ZYPE_CLIENT_TOKEN ?? ''} />;
 
 export const Instagram = () => (
-  <InstagramEmbedCloned
+  <InstagramEmbed
     source="https://www.instagram.com/p/CXMZEJGLRqq/"
-    caption=""
+  />
+);
+
+export const InstagramWithCaption = () => (
+  <InstagramEmbed
+    source="https://www.instagram.com/p/CXMZEJGLRqq/"
+    caption={longCaptionText}
   />
 );
 
 export const GenericIframe = () => (
   <MediaEmbed
-    caption=""
     site="Other"
     source={stackblitzUrl}
+  />
+);
+
+export const GenericIframeWithCaption = () => (
+  <MediaEmbed
+    site="Other"
+    source={stackblitzUrl}
+    caption={longCaptionText}
   />
 );
 
@@ -85,29 +112,24 @@ export const MobileMediaEmbeds = () => (
     <MediaEmbed
       source={tiktokUrl}
       site="TikTok"
-      caption=""
     />
     <MediaEmbed
       source={youtubeUrl}
       site="YouTube"
-      caption=""
     />
     <MediaEmbed
       source={instagramUrl}
       site="Instagram"
-      caption=""
     />
     <MediaEmbed
       source={instagramUrl}
       site="Instagram"
-      caption="add caption"
     />
     {/* iframe embed requires explicit sizing */}
     <div style={{ height: '400px' }}>
       <MediaEmbed
         source={stackblitzUrl}
         site="Other"
-        caption=""
       />
     </div>
   </div>

--- a/src/components/MediaEmbed/MediaEmbed.tsx
+++ b/src/components/MediaEmbed/MediaEmbed.tsx
@@ -146,8 +146,10 @@ export function InstagramEmbed({ source, caption }: EmbedProps) {
   );
 }
 
-export function ZypeEmbed({ source, caption, token }: EmbedProps & { token: string; }) {
-  useScript(`https://player.zype.com/embed/${source}.js?api_key=${token}&controls=true&da=true`);
+export function ZypeEmbed({
+  source, caption, autoplay = false, token,
+}: EmbedProps & { autoplay?: boolean; token: string; }) {
+  useScript(`https://player.zype.com/embed/${source}.js?api_key=${token}&autoplay=${autoplay}&controls=true&da=true`);
   return (
     <div>
       <AspectRatio>

--- a/src/components/MediaEmbed/MediaEmbed.tsx
+++ b/src/components/MediaEmbed/MediaEmbed.tsx
@@ -1,7 +1,48 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import useResizeObserver from 'use-resize-observer/polyfilled';
+import { withThemes, color, font } from '../../styles';
 import { useOEmbed, useScript } from './utilities';
+
+type EmbedProps = { source: string; caption?: string };
+
+const EmbedWrapperInner = styled.div`
+  width: min-content;
+`;
+
+const DescriptionWrapper = styled.div`
+  padding-top: 16px;
+`;
+
+const Description = styled.span`
+  font-family: ${font.pnb};
+  font-size: 16px;
+  line-height: 1.5;
+  color: ${color.doveGray};
+`;
+
+const AccentRectangle = styled.div`
+  width: 19.5px;
+  height: 7px;
+  margin-top: 8px;
+  ${withThemes({
+    default: css`background-color: ${color.mint};`,
+    atk: css`background-color: ${color.mint};`,
+    cco: css`background-color: ${color.bermudaGray};`,
+    cio: css`background-color: ${color.squirrel};`,
+  })}
+`;
+
+function Caption({ caption }: { caption?: string }) {
+  return caption ? (
+    <DescriptionWrapper>
+      <Description>
+        {caption}
+      </Description>
+      <AccentRectangle />
+    </DescriptionWrapper>
+  ) : null;
+}
 
 /** Aspect ratio component for iframe child components */
 const AspectRatio = styled.div<{ children?: JSX.IntrinsicElements['iframe'] }>`
@@ -29,18 +70,21 @@ function getYoutubeId(source: string): string | null {
 }
 
 // https://youtu.be/pgHCA1MUAxE and https://www.youtube.com/watch?v=pgHCA1MUAxE
-export function YoutubeEmbed({ source }: { source: string }) {
+export function YoutubeEmbed({ source, caption }: EmbedProps) {
   const videoId = getYoutubeId(source);
   return videoId ? (
-    <AspectRatio>
-      <iframe
-        title="ytplayer"
-        src={`https://www.youtube.com/embed/${videoId}`}
-        frameBorder="0"
-        width="640"
-        height="360"
-      />
-    </AspectRatio>
+    <div>
+      <AspectRatio>
+        <iframe
+          title="ytplayer"
+          src={`https://www.youtube.com/embed/${videoId}`}
+          frameBorder="0"
+          width="640"
+          height="360"
+        />
+      </AspectRatio>
+      <Caption caption={caption} />
+    </div>
   ) : null;
 }
 
@@ -51,14 +95,14 @@ const OverridesTikTokEmbed = styled.div<{lessThan542: boolean}>`
       // since we can't change cross-origin background color of iframe.
       //  we are using the iframe's content breakpoints and matching the 
       //  iframe size to the content size.
-      width: ${({ lessThan542 }) => (lessThan542 ? '323px' : '542px')} !important;
+      width: ${({ lessThan542 }) => (lessThan542 ? '323px' : '544px')} !important;
       border-radius: 8px;
       overflow: hidden;
     }
   }
 `;
 
-export function TikTokEmbed({ source }: { source: string }) {
+export function TikTokEmbed({ source, caption }: EmbedProps) {
   const { width = 0, ref } = useResizeObserver();
   const embed = useOEmbed({
     baseUrl: 'https://www.tiktok.com/oembed?url=',
@@ -66,44 +110,61 @@ export function TikTokEmbed({ source }: { source: string }) {
     source,
   });
   return (
-    <OverridesTikTokEmbed
-      ref={ref}
-      lessThan542={width < 542}
-      dangerouslySetInnerHTML={{ __html: embed?.html ?? '' }}
-    />
+    <div ref={ref}>
+      <EmbedWrapperInner>
+        <OverridesTikTokEmbed
+          lessThan542={width < 542}
+          dangerouslySetInnerHTML={{ __html: embed?.html ?? '' }}
+        />
+        <Caption caption={caption} />
+      </EmbedWrapperInner>
+    </div>
   );
 }
 
 const loadingTextLink = "A post shared by America's Test Kitchen";
 const instagramTemplate = (source: string, caption?: boolean) => `<blockquote class="instagram-media" ${caption ? 'data-instgrm-captioned' : ''} data-instgrm-permalink="https://www.instagram.com/reel/${source}/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="14" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:16px;"> <a href="https://www.instagram.com/reel/${source}/?utm_source=ig_embed&amp;utm_campaign=loading" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank"> <div style=" display: flex; flex-direction: row; align-items: center;"> <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div></div></div><div style="padding: 19% 0;"></div> <div style="display:block; height:50px; margin:0 auto 12px; width:50px;"><svg width="50px" height="50px" viewBox="0 0 60 60" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-511.000000, -20.000000)" fill="#000000"><g><path d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"></path></g></g></g></svg></div><div style="padding-top: 8px;"> <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;">View this post on Instagram</div></div><div style="padding: 12.5% 0;"></div> <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"><div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div> <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div></div><div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div> <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div></div><div style="margin-left: auto;"> <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div> <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div> <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div></div></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 224px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;"></div></div></a><p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/reel/${source}/?utm_source=ig_embed&amp;utm_campaign=loading" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">${loadingTextLink}</a></p></div></blockquote> <script async src="//www.instagram.com/embed.js"></script>`;
 
-const InstagramEmbedWrapper = styled.div`
-  max-width: 487px;
+const InstagramEmbedWrapper = styled.div<{lessThan542: boolean}>`
+  width: ${({ lessThan542 }) => (lessThan542 ? '323px' : '542px')} !important;
 `;
 
-export function InstagramEmbedCloned({ source, caption }: { source: string; caption: string; }) {
+export function InstagramEmbed({ source, caption }: EmbedProps) {
+  const { width = 0, ref } = useResizeObserver();
   useScript('//www.instagram.com/embed.js', () => window.instgrm?.Embeds.process());
   const postId = source.slice(source.lastIndexOf('p/') + 1).replace(/\//g, '');
   return (
-    <InstagramEmbedWrapper
-      dangerouslySetInnerHTML={{ __html: postId && instagramTemplate(postId, !!caption) }}
-    />
+    <div ref={ref}>
+      <EmbedWrapperInner>
+        <InstagramEmbedWrapper
+          lessThan542={width < 542}
+          dangerouslySetInnerHTML={{ __html: postId && instagramTemplate(postId) }}
+        />
+        <Caption caption={caption} />
+      </EmbedWrapperInner>
+    </div>
   );
 }
 
-export function InstagramEmbed({ source, token }: { source: string; token: string }) {
-  const payload = useOEmbed({
-    baseUrl: `https://graph.facebook.com/v12.0/instagram_oembed?access_token=${token}&url=`,
-    script: '//www.instagram.com/embed.js',
-    source,
-    onLoad: () => window.instgrm?.Embeds.process(),
-  });
-  return <InstagramEmbedWrapper dangerouslySetInnerHTML={{ __html: payload?.html ?? '' }} />;
+export function ZypeEmbed({ source, caption, token }: EmbedProps & { token: string; }) {
+  useScript(`https://player.zype.com/embed/${source}.js?api_key=${token}&controls=true&da=true`);
+  return (
+    <div>
+      <AspectRatio>
+        <div id={`zype_${source}`} />
+      </AspectRatio>
+      <Caption caption={caption} />
+    </div>
+  );
 }
 
-export function ZypeEmbed({ source, token }: { source: string; token: string; }) {
-  useScript(`https://player.zype.com/embed/${source}.js?api_key=${token}&controls=true&da=true`);
-  return <div id={`zype_${source}`} />;
+export function OtherEmbed({ source, caption }: EmbedProps) {
+  return (
+    <div>
+      <iframe src={source} title={caption} width="100%" height="100%" style={{ border: 'none' }} />
+      <Caption caption={caption} />
+    </div>
+  );
 }
 
 export type MediaEmbedType = 'TikTok' | 'YouTube' | 'Instagram' | 'Other' | unknown;
@@ -113,7 +174,7 @@ export type MediaEmbedProps = {
    * Not yet in line with barista expectations, right now truthiness gets the instagram
    *  post with caption option when included.
    */
-  caption: string;
+  caption?: string;
   /**
    * One of the supported dynamic media types, selects proper element.
    * Other or unknown return iframes.
@@ -127,11 +188,6 @@ export type MediaEmbedProps = {
 }
 
 type MediaTokens = {
-  /**
-   * When not provided, insert post id into copied instagram embed code
-   * https://developers.facebook.com/docs/facebook-login/access-tokens#clienttokens
-   */
-  facebook?: string;
   /** Player token required for client */
   zype?: string;
 }
@@ -143,20 +199,16 @@ export default function MediaEmbed(
   { caption, site, source, tokens = {} }: MediaEmbedProps & { tokens?: MediaTokens },
 ) {
   switch (site) {
-    case 'TikTok': return <TikTokEmbed source={source} />;
+    case 'TikTok': return <TikTokEmbed source={source} caption={caption} />;
     case 'YouTube': return <YoutubeEmbed source={source} />;
-    case 'Instagram': return tokens?.facebook ? (
-      <InstagramEmbed source={source} token={tokens.facebook} />
-    ) : (
-      <InstagramEmbedCloned source={source} caption={caption} />
-    );
+    case 'Instagram': return <InstagramEmbed source={source} caption={caption} />;
     case 'Zype': return tokens?.zype ? (
       <ZypeEmbed source={source} token={tokens.zype} />
     ) : (
       // eslint-disable-next-line no-console
       <>{console.warn('Zype client token is missing!')}</>
     );
-    case 'Other': return <iframe src={source} title={caption} width="100%" height="100%" style={{ border: 'none' }} />;
+    case 'Other': return <OtherEmbed source={source} caption={caption} />;
     default: return <iframe src={source} title={caption} width="100%" height="100%" style={{ border: 'none' }} />;
   }
 }


### PR DESCRIPTION
- ARCHIE-3161: Captions moved to mise-ui for min-content usage inside resize observer references
- ARCHIE-3220: Add as prop to article text block heading
- remove unavailable static directory from storybook scripts
- add autoplay option for zype embed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.27.1--canary.595.e791698.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @atk/mise-ui@1.27.1--canary.595.e791698.0
  # or 
  yarn add @atk/mise-ui@1.27.1--canary.595.e791698.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
