### PR TITLE
CORE-39

### DIFF
--- a/src/components/ActionSummaryItem/index.js
+++ b/src/components/ActionSummaryItem/index.js
@@ -21,7 +21,7 @@ const ActionSummaryTheme = {
     }
 
     svg {
-      height  1.6rem;
+      height: 1.6rem;
       margin-right: ${spacing.xxsm};
       position: relative;
       top: -1px;

--- a/src/components/Cards/FeatureCard/FeatureCard.stories.js
+++ b/src/components/Cards/FeatureCard/FeatureCard.stories.js
@@ -100,6 +100,9 @@ export const WideWithCTA = () => (
     imageAlt={text('Image alt text', 'Lorem ipsum')}
     imageUrl={text('Image url', 'https://res.cloudinary.com/hksqkdlah/image/upload/v1592916093/mise-play/feature-card-wide-cta.jpg')}
     isWide
+    commentsCount={5}
+    numRatings={4}
+    avgRating={3.66}
     siteKey="atk"
     siteKeyFavorites="atk"
     stickers={[{ type: 'editorial', text: 'Popular'}]}

--- a/src/components/Cards/FeatureCard/index.js
+++ b/src/components/Cards/FeatureCard/index.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 import { color, font, fontSize, grid, lineHeight, mixins, spacing } from '../../../styles';
+import { FeatureCardUserAttributions } from '../shared/UserAttributions';
 import Badge from '../../Badge';
 import FavoriteRibbonWithBg from '../shared/FavoriteRibbonWithBg';
 import Image from '../shared/Image';
 import PersonHeadShot from '../shared/PersonHeadShot';
 import Sticker from '../shared/Sticker';
 import Title from '../shared/Title';
-import { Comment as CommentIcon } from '../../DesignTokens/Icon';
 
 const featureCardWidth = grid.columnWidth;
 const featureCardWideWidth = `${parseFloat(grid.columnWidth) * 2 + parseFloat(grid.gutterWidth)}rem`;
@@ -117,12 +117,6 @@ const Attributions = styled.p.attrs({
   font: ${fontSize.md}/${lineHeight.md} ${font.pnb};
 `;
 
-const Comments = styled.p.attrs({
-  className: 'feature-card__num-comments',
-})`
-  font: ${fontSize.md}/${lineHeight.md} ${font.pnb};
-`;
-
 const CtaLink = styled.a`
   ${mixins.styledLink(color.tomato, color.rust, color.white)};
   bottom: ${spacing.sm};
@@ -150,7 +144,9 @@ const OriginalPricing = styled.p`
 
 function FeatureCard({
   attributions,
+  avgRating,
   className,
+  commentsCount,
   contentType,
   ctaDataAttrs,
   ctaText,
@@ -164,7 +160,7 @@ function FeatureCard({
   isFavorited,
   isWide,
   lazyImage,
-  commentsCount,
+  numRatings,
   objectId,
   onClick,
   originalPrice,
@@ -223,12 +219,11 @@ function FeatureCard({
               </StickerGroup>
             ) : null}
             <StyledTitle className={className} title={title} />
-            {commentsCount ? (
-              <Comments>
-                <CommentIcon fill="white" style={{ width: '16px', height: '16px' }} />
-                &nbsp;{commentsCount}
-              </Comments>
-            ) : null}
+            <FeatureCardUserAttributions
+              avgRating={avgRating}
+              commentsCount={commentsCount || null}
+              numRatings={numRatings}
+            />
             {attributions ? <Attributions>{attributions}</Attributions> : null}
             {originalPrice && discountedPrice ? (
               <PricingWrapper>
@@ -283,6 +278,8 @@ FeatureCard.propTypes = {
   isWide: PropTypes.bool,
   lazyImage: PropTypes.bool,
   commentsCount: PropTypes.number,
+  avgRating: PropTypes.number,
+  numRatings: PropTypes.number,
   objectId: PropTypes.string.isRequired,
   onClick: PropTypes.func,
   originalPrice: PropTypes.string,
@@ -311,6 +308,8 @@ FeatureCard.defaultProps = {
   isWide: false,
   lazyImage: true,
   commentsCount: 0,
+  avgRating: null,
+  numRatings: null,
   onClick: null,
   originalPrice: null,
   personHeadShot: null,

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { css, ThemeProvider } from 'styled-components';
+import styled, { css } from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 import { cards, color, fontSize, mixins, spacing, withThemes } from '../../../styles';
-import ActionSummaryItem from '../../ActionSummaryItem';
+import { StandardUserAttributions } from '../shared/UserAttributions/UserAttributions';
 import Attributions from '../shared/Attributions';
 import Badge from '../../Badge';
 import CtaLink from '../shared/CtaLink';
@@ -47,15 +47,6 @@ const StandardCardTheme = {
     }
   `,
 };
-
-const RecipeAttribution = styled.div`
-  display: flex;
-  margin: 0.3rem 0 0.6rem 0;
-
-  .icon--star {
-    margin-right: 1.6rem;
-  }
-`;
 
 const StyledStandardCard = styled.article`
   ${withThemes(StandardCardTheme)}
@@ -276,26 +267,11 @@ function StandardCard({
         </TitleWrapper>
       </>
       {searchAttribution && (
-        <RecipeAttribution
-          // eslint-disable-next-line
-          aria-label={`${avgRating > 0 ? `${avgRating} star${avgRating === 1 ? '' : 's'} ${numRatings} rating${numRatings === 1 ? '' : 's'}` : ''} ${searchComments ? `${searchComments} comment${searchComments === 1 ? '' : 's'}` : ''}`}
-          aria-hidden={!avgRating && !searchComments}
-          role="presentation"
-          tabIndex={!avgRating && !searchComments ? '-1' : '0'}
-        >
-          {avgRating && displayRecipeAttribution && (
-            <ThemeProvider theme={{ siteKey: 'atk' }}>
-              <ActionSummaryItem icon="star">
-                <div aria-hidden="true"><strong>{avgRating}</strong>&nbsp;<span>{`(${numRatings})`}</span></div>
-              </ActionSummaryItem>
-            </ThemeProvider>
-          )}
-          {searchComments && (
-            <ActionSummaryItem icon="comment">
-              <strong aria-hidden="true">{searchComments}</strong>
-            </ActionSummaryItem>
-          )}
-        </RecipeAttribution>
+        <StandardUserAttributions
+          commentsCount={searchComments}
+          numRatings={displayRecipeAttribution ? numRatings : null}
+          avgRating={displayRecipeAttribution ? avgRating : null}
+        />
       )}
       <StyledAttributions
         displayCookbook={displayCookbook}

--- a/src/components/Cards/shared/UserAttributions/UserAttributions.stories.tsx
+++ b/src/components/Cards/shared/UserAttributions/UserAttributions.stories.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ThemeProvider } from 'styled-components';
+import { storybookParameters } from '../../../../config/shared.stories';
+import UserAttributions, { UserAttributionsProps, FeatureCardUserAttributions, StandardUserAttributions } from './UserAttributions';
+
+export default {
+  title: 'Components/Cards/shared/UserAttributions',
+  component: UserAttributions,
+  ...storybookParameters,
+} as ComponentMeta<typeof UserAttributions>;
+
+function DisplayAriaLabels({ numRatings, commentsCount, avgRating }: UserAttributionsProps) {
+  const [labels, setLabels] = useState<string[]>([]);
+
+  useEffect(() => {
+    const ariaLabelElements = Array.from(document.querySelectorAll('[aria-label]').values()).map(element => element.ariaLabel ?? '');
+    setLabels(ariaLabelElements);
+  }, [numRatings, commentsCount, avgRating]);
+
+  return (
+    <div>
+      {labels}
+    </div>
+  );
+}
+
+const Template = (args: UserAttributionsProps) => (
+  <>
+    <UserAttributions {...args} />
+    <DisplayAriaLabels {...args} />
+  </>
+);
+
+export const Default: ComponentStory<typeof UserAttributions> = Template.bind({});
+Default.args = {
+  avgRating: 4,
+  numRatings: 10,
+  commentsCount: 3,
+};
+
+export const atkUserAttributions = () => (
+  <ThemeProvider theme={{ siteKey: 'atk' }}>
+    <StandardUserAttributions {...Default.args} />
+  </ThemeProvider>
+);
+
+export const ccoUserAttributions = () => (
+  <ThemeProvider theme={{ siteKey: 'cco' }}>
+    <StandardUserAttributions {...Default.args} />
+  </ThemeProvider>
+);
+
+export const cioUserAttributions = () => (
+  <ThemeProvider theme={{ siteKey: 'cio' }}>
+    <StandardUserAttributions {...Default.args} />
+  </ThemeProvider>
+);
+
+export const featureCardUserAttributions = () => (
+  <ThemeProvider theme={{ siteKey: 'atk' }}>
+    <div style={{ background: 'black', padding: '16px' }}>
+      <FeatureCardUserAttributions {...Default.args} />;
+    </div>
+  </ThemeProvider>
+);

--- a/src/components/Cards/shared/UserAttributions/UserAttributions.tsx
+++ b/src/components/Cards/shared/UserAttributions/UserAttributions.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import styled from 'styled-components';
+import { color, fontSize, lineHeight, font } from '../../../../styles';
+import type { InferStyledTypes } from '../../../../styles/utility-types';
+import ActionSummaryItem from '../../../ActionSummaryItem';
+
+const Wrapper = styled.div`
+  display: flex;
+
+  .icon--star {
+    margin-right: 1.6rem;
+  }
+`;
+
+export type UserAttributionsProps = InferStyledTypes<typeof Wrapper> & {
+  avgRating?: number;
+  numRatings?: number;
+  commentsCount?: number;
+};
+
+export default function UserAttributions({
+  avgRating,
+  numRatings,
+  commentsCount,
+  ...styledProps
+}: UserAttributionsProps) {
+  const hasCommentsCount = typeof commentsCount === 'number';
+  const hasRatings = typeof avgRating === 'number' && typeof numRatings === 'number';
+  const hasNoData = !hasRatings && !hasCommentsCount;
+  const avgRatingRound = hasRatings ? (Math.round(10 * avgRating) / 10).toFixed(1) : undefined;
+
+  const ratingsAria = `${avgRating && avgRating > 0 ? `${avgRatingRound} star${avgRatingRound === '1.0' ? '' : 's'} ${numRatings} rating${numRatings === 1 ? '' : 's'}` : ''}`;
+  const commentsAria = `${commentsCount ? `${commentsCount} comment${commentsCount === 1 ? '' : 's'}` : ''}`;
+
+  return (
+    <Wrapper
+      aria-label={`${ratingsAria} ${commentsAria}`}
+      aria-hidden={hasNoData}
+      role="presentation"
+      tabIndex={hasNoData ? -1 : 0}
+      {...styledProps}
+    >
+      {hasRatings && (
+        <ActionSummaryItem icon="star">
+          <div aria-hidden="true"><strong>{avgRatingRound}</strong>&nbsp;<span>{`(${numRatings})`}</span></div>
+        </ActionSummaryItem>
+      )}
+      {hasCommentsCount && (
+        <ActionSummaryItem icon="comment">
+          <strong aria-hidden="true">{commentsCount}</strong>
+        </ActionSummaryItem>
+      )}
+    </Wrapper>
+  );
+}
+
+export const StandardUserAttributions = styled(UserAttributions)`
+  margin: 0.3rem 0 0.6rem 0;
+`;
+
+export const FeatureCardUserAttributions = styled(UserAttributions)`
+  margin: 0.3rem 0 0.6rem 0;
+  color: ${color.white};
+  font: ${fontSize.md}/${lineHeight.md} ${font.pnb};
+
+  .action-summary {
+    color: ${color.white};
+    path {
+      fill: white !important;
+    }
+  }
+`;

--- a/src/components/Cards/shared/UserAttributions/index.tsx
+++ b/src/components/Cards/shared/UserAttributions/index.tsx
@@ -1,0 +1,2 @@
+export { default as UserAttributions } from './UserAttributions';
+export * from './UserAttributions';


### PR DESCRIPTION
refactors attributions in standard card and adds to feature card

Requires: https://github.com/Americastestkitchen/jarvis/pull/1572 for search page themes
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.32.1--canary.619.05720a3.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @atk/mise-ui@1.32.1--canary.619.05720a3.0
  # or 
  yarn add @atk/mise-ui@1.32.1--canary.619.05720a3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
