### PR TITLE
ARCHIE-3166 - Topic carousel header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atk/mise-ui",
-  "version": "1.33.3",
+  "version": "1.33.4--canary.203689f.0",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.14.5",
     "algoliasearch": "^4.0.3",

--- a/src/components/Ads/ReviewsAds/ReviewsMarketingHat/__tests__/ReviewsMarketingHat.spec.js
+++ b/src/components/Ads/ReviewsAds/ReviewsMarketingHat/__tests__/ReviewsMarketingHat.spec.js
@@ -13,6 +13,7 @@ const defaultResponse = {
   incode: 'MAR2DAA1A',
   inputId: 'email-form__input',
   mdc: 'AF0150MA1D',
+  promoId: 'a-promo-about-700-eggs',
   subdomain: 'www-test',
   title: 'Rejoin Now',
   user: { testing: true },

--- a/src/components/Cards/RelatedContentCard/RelatedContentCard.tsx
+++ b/src/components/Cards/RelatedContentCard/RelatedContentCard.tsx
@@ -1,11 +1,10 @@
-import React, { ComponentProps, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
+import React, { ComponentProps, PropsWithChildren, useContext, useEffect, useState } from 'react';
 import styled, { css, DefaultTheme, ThemeContext, ThemeProvider } from 'styled-components';
 import { font, color, withThemes, mixins } from '../../../styles';
 import { md, untilMd } from '../../../styles/breakpoints';
 import { cssThemedColor, cssThemedFontAccentColorAlt, cssThemedLink } from '../../../styles/mixins';
 import useMedia from '../../hooks/useMedia';
 import AffiliateLink from '../shared/AffiliateLink';
-import Image from '../shared/Image';
 
 const mobileCard = untilMd;
 const desktopCard = md;
@@ -157,7 +156,7 @@ export function Wrapper({ src, children, ...anchorProps }: WideCardWrapperProps)
     } else {
       setImageSize(200 + offset);
     }
-  }, [isMobile]);
+  }, [isMobile, offset]);
 
   return (
     <Card {...anchorProps}>

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -289,13 +289,13 @@ function StandardCard({
               </ActionSummaryItem>
             </ThemeProvider>
           )}
-          {searchComments && (
+          {searchComments ? (
             <ThemeProvider theme={{ siteKey: 'atk' }}>
               <ActionSummaryItem icon="comment">
                 <strong aria-hidden="true">{searchComments}</strong>
               </ActionSummaryItem>
             </ThemeProvider>
-          )}
+          ) : null}
         </RecipeAttribution>
       )}
       <StyledAttributions

--- a/src/components/Carousels/BaseCarousel/BaseCarousel.stories.tsx
+++ b/src/components/Carousels/BaseCarousel/BaseCarousel.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentStory } from '@storybook/react';
 import { defaultTheme, setBackground, setViewport, storybookParameters } from '../../../config/shared.stories';
 import BaseCarousel, { useCarouselContext } from './BaseCarousel';
 import StandardCard from '../../Cards/StandardCard';
-import { LinkCarouselHeader, IntroCarouselHeader } from './Headers';
+import { LinkCarouselHeader, IntroCarouselHeader, TopicCarouselHeader } from './Headers';
 import { useFlickityGroup } from './useFlickity';
 import { FullWidthSlide, StandardSlide } from './Slides';
 import { CarouselWidthWrapper } from './Wrappers';
@@ -98,6 +98,7 @@ const recipeItems = [
     href: '/recipes/8125',
     imageAlt: 'Chocolate Crinkle Cookies',
     imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/ar_1:1,c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_344/22391_sfs-chocolate-crinkle-cookies-35',
+    id: 'recipe_8125',
     objectId: 'recipe_8125',
     siteKey: 'atk',
     siteKeyFavorites: 'atk',
@@ -113,6 +114,7 @@ const recipeItems = [
     href: '/recipes/8125',
     imageAlt: 'Chocolate Crinkle Cookies',
     imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/ar_1:1,c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_344/22391_sfs-chocolate-crinkle-cookies-35',
+    id: 'recipe_8125-2',
     objectId: 'recipe_8125',
     siteKey: 'atk',
     siteKeyFavorites: 'atk',
@@ -128,6 +130,7 @@ const recipeItems = [
     href: '/recipes/8125',
     imageAlt: 'Chocolate Crinkle Cookies',
     imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/ar_1:1,c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_344/22391_sfs-chocolate-crinkle-cookies-35',
+    id: 'recipe_8125-2.5',
     objectId: 'recipe_8125',
     siteKey: 'atk',
     siteKeyFavorites: 'atk',
@@ -143,6 +146,7 @@ const recipeItems = [
     href: '/recipes/8125',
     imageAlt: 'Chocolate Crinkle Cookies',
     imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/ar_1:1,c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_344/22391_sfs-chocolate-crinkle-cookies-35',
+    id: 'recipe_8125-3',
     objectId: 'recipe_8125',
     siteKey: 'atk',
     siteKeyFavorites: 'atk',
@@ -158,6 +162,7 @@ const recipeItems = [
     href: '/recipes/8125',
     imageAlt: 'Chocolate Crinkle Cookies',
     imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/ar_1:1,c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_344/22391_sfs-chocolate-crinkle-cookies-35',
+    id: 'recipe_8125-4',
     objectId: 'recipe_8125',
     siteKey: 'atk',
     siteKeyFavorites: 'atk',
@@ -173,6 +178,7 @@ const recipeItems = [
     href: '/recipes/8125',
     imageAlt: 'Chocolate Crinkle Cookies',
     imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/ar_1:1,c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_344/22391_sfs-chocolate-crinkle-cookies-35',
+    id: 'recipe_8125-5',
     objectId: 'recipe_8125',
     siteKey: 'atk',
     siteKeyFavorites: 'atk',
@@ -188,6 +194,7 @@ const recipeItems = [
     href: '/recipes/8125',
     imageAlt: 'Chocolate Crinkle Cookies',
     imageUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/ar_1:1,c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_344/22391_sfs-chocolate-crinkle-cookies-35',
+    id: 'recipe_8125-6',
     objectId: 'recipe_8125',
     siteKey: 'atk',
     siteKeyFavorites: 'atk',
@@ -221,6 +228,29 @@ export const PhotoCarouselIntroExample = () => (
         </FullWidthSlide>
       ))}
     </BaseCarousel>
+  </PreviewProvider>
+);
+
+export const RecipeCarouselTopicExample = () => (
+  <PreviewProvider siteKey="atk">
+    <CarouselWidthWrapper
+      maxWidthPx={847}
+      overflowAuto
+    >
+      <BaseCarousel
+        useFlickityHook={useFlickityGroup}
+        title="Recipe Carousel"
+        header={
+          <TopicCarouselHeader title="Recipe Carousel Title" topic="Recipe Carousel Title" />
+        }
+      >
+        {recipeItems.map(item => (
+          <StandardSlide key={item.id}>
+            <StandardCard key={item.objectId} {...item} />
+          </StandardSlide>
+        ))}
+      </BaseCarousel>
+    </CarouselWidthWrapper>
   </PreviewProvider>
 );
 

--- a/src/components/Carousels/BaseCarousel/Headers.tsx
+++ b/src/components/Carousels/BaseCarousel/Headers.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import { md } from '../../../styles/breakpoints';
 import { mixins } from '../../../styles';
-import { Intro, Subtitle, Title } from './styled-elements';
+import { Intro, Subtitle, Title, Topic } from './styled-elements';
 
 const arrowPath = 'M 45.4883 88.5586 C 48.082 92.5664 53.2734 93.7109 57.3086 91.4219 C 61.3477 88.8477 62.5 83.6953 60.1953 79.6914 L 40.0078 47.6445 L 60.1953 15.5977 C 62.7891 11.5898 61.6367 6.1523 57.3086 3.8633 C 55.8672 3.0078 54.4258 2.4336 52.6953 2.4336 C 49.8125 2.4336 46.9297 3.8633 45.4883 6.4414 L 19.5352 47.6445 L 45.4883 88.5586 Z M 45.4883 88.5586';
 
@@ -70,6 +70,24 @@ export function IntroCarouselHeader({ title, intro }: IntroCarouselHeaderProps) 
     <div>
       <Title>{title}</Title>
       {!!intro && <Intro dangerouslySetInnerHTML={{ __html: intro }} />}
+    </div>
+  );
+}
+
+type TopicCarouselHeaderProps = {
+  title: string;
+  topic?: string;
+}
+
+export function TopicCarouselHeader({ title, topic }: TopicCarouselHeaderProps) {
+  return (
+    <div>
+      {!!topic && (
+        <Topic>
+          {topic}
+        </Topic>
+      )}
+      <Title>{title}</Title>
     </div>
   );
 }

--- a/src/components/Carousels/BaseCarousel/bug-fixes.ts
+++ b/src/components/Carousels/BaseCarousel/bug-fixes.ts
@@ -26,7 +26,7 @@ export function fixLeftOverflow(this: any): void {
     apply(fnTarget, thisArg, [x, is3d]) {
       // TODO: needs better utility for changing this value.
       const offset = thisArg.options.offset ?? 100;
-      const newX = x > -offset ? x - thisArg.slideableWidth : x;
+      const newX = x > -offset && thisArg.options.wrapAround ? x - thisArg.slideableWidth : x;
       const result = fnTarget.apply(thisArg, [newX, is3d]);
       return result;
     },

--- a/src/components/Carousels/BaseCarousel/styled-elements.tsx
+++ b/src/components/Carousels/BaseCarousel/styled-elements.tsx
@@ -99,6 +99,14 @@ export const Intro = styled.div`
   }
 `;
 
+export const Topic = styled.div`
+  ${cssThemedColor}
+  font-family: ${font.pnb};
+  font-size: 16px;
+  line-height: 1.1666;
+  margin: 0 0 18px;
+`;
+
 export const Subtitle = styled.span`
   ${cssThemedColor}
   font-family: ${font.pnr};

--- a/src/components/Carousels/BaseCarousel/useFlickity.ts
+++ b/src/components/Carousels/BaseCarousel/useFlickity.ts
@@ -5,10 +5,16 @@ import React, { useCallback, useState, useEffect, useRef, MutableRefObject, Disp
 import useResizeObserver from 'use-resize-observer';
 import { fixIosScrollBehavior, fixLeftOverflow } from './bug-fixes';
 
+/**
+ * Allow for slight overflow related to margin on the last slide.
+ * @param flkty Flickity instance
+ * @returns Boolean if all slides are visible
+ */
 function isAllSlidesVisible(flkty: any): boolean {
   const slideableWidth = flkty?.slideableWidth;
   const availableWidth = flkty?.size?.innerWidth;
-  return availableWidth >= slideableWidth;
+  const overflowPercent = (slideableWidth - availableWidth) / slideableWidth;
+  return (availableWidth >= slideableWidth) || (overflowPercent <= 0.05);
 }
 
 /**


### PR DESCRIPTION
New `TopicCarouselHeader` header bit for the basic carousel. Add in some tolerance for slight overflow when determining if all cells are visible. The right margin on the standard cards causes a slight overflow that Flickity picks up internally, making the pagination useless but still enabled because the `isAllSlidesVisible` check was not returning `true`.