### PR TITLE
SEARCH-106: search page need visible checkbox without site key

### DIFF
--- a/src/components/Algolia/shared/SortBy/SortBy.stories.js
+++ b/src/components/Algolia/shared/SortBy/SortBy.stories.js
@@ -17,6 +17,7 @@ const items = [
   { value: 'everest_search_development', label: 'Relevance' },
   { value: 'everest_search_popularity_desc_development', label: 'Popularity' },
   { value: 'everest_search_published_date_desc_development', label: 'Publish Date' },
+  { value: "everest_search_avg_rating_desc_development", label: "Top Rated", isNew: true }
 ];
 
 const Template = (args) => (

--- a/src/components/Algolia/shared/SortBy/index.js
+++ b/src/components/Algolia/shared/SortBy/index.js
@@ -80,16 +80,18 @@ const SearchSortByItem = styled.div`
 `;
 
 const SearchSortByNew = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 0.8rem;
+  height: 2rem;
+  width: 4.2rem;
+  border-radius: 0.6rem;
   background-color: ${color.tomato};
-  border-radius: 0.5rem;
   color: ${color.white};
-  font: ${fontSize.xsm}/1.2rem ${font.pnb};
-  letter-spacing: 1.25px;
-  margin-left: ${spacing.xsm};
-  padding: 2px 0px 1px 2px;
-  text-align: center;
+  font: ${fontSize.xsm} / 1.8rem ${font.pnb};
+  letter-spacing: 1.6px;
   text-transform: uppercase;
-  width: 3.4rem;
 `;
 
 const SearchSortByRadioInputTheme = {

--- a/src/components/Algolia/shared/SortBy/index.js
+++ b/src/components/Algolia/shared/SortBy/index.js
@@ -111,6 +111,14 @@ const SearchSortByCircleTheme = {
     height: 1.2rem;
     margin-right: 0.6rem;
     width: 1.2rem;
+
+    border: solid 1px ${color.nobel};
+
+    ${({ isRefined }) => (isRefined ? `
+        background-color: ${color.mint};
+    ` : `
+        background-color: transparent;
+    `)}
   `,
   atk: css`
     border: solid 1px ${color.nobel};


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.33.5--canary.635.3578b08.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @atk/mise-ui@1.33.5--canary.635.3578b08.0
  # or 
  yarn add @atk/mise-ui@1.33.5--canary.635.3578b08.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
