### PR TITLE
CORE-142: don't translate disabled carousel cells when its parent has display flex.

### DIFF
--- a/src/components/Carousels/Carousel/index.js
+++ b/src/components/Carousels/Carousel/index.js
@@ -61,6 +61,10 @@ const CarouselTheme = {
       display: flex;
       overflow: hidden;
 
+      .carousel-cell {
+        transform: none !important;
+      }
+
       .slideshow & {
         .carousel-cell {
           display: flex;


### PR DESCRIPTION
From this episode carousel.
https://www.cookscountry.com/episode/798-chicken-soup-and-cheesy-bread
Works fine with enough items.

Issues with not enough items
https://www.cookscountry.com/episode/796-pork-peaches-and-potatoes
https://www.cookscountry.com/episode/797-french-fare
Disabled carousels here are getting display flex, but translate values on carousel are still rendering items translated off screen.

https://www-dev.cookscountry.com/episode/796-pork-peaches-and-potatoes
https://www-dev.cookscountry.com/episode/797-french-fare
Adding transform none removes translate values when flickity is disabled.