### PR TITLE
CORE-210: If menu is not valid, clear filtered items

### DIFF
--- a/src/components/Algolia/shared/Menu/index.js
+++ b/src/components/Algolia/shared/Menu/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { connectMenu } from 'react-instantsearch-dom';
@@ -16,20 +16,29 @@ const MenuWrapper = styled.ul`
   }
 `;
 
-const Menu = ({ items, onClickItem, ...restProps }) => (
-  <MenuWrapper hasItems={items && items.length > 0}>
-    {
-      items.map(item => (
+const Menu = ({ items, onClickItem, ...restProps }) => {
+  const { currentRefinement, canRefine, refine } = restProps;
+
+  /** If menu is not valid, clear filtered items */
+  useEffect(() => {
+    if (!canRefine && currentRefinement) {
+      refine();
+    }
+  }, [currentRefinement, canRefine, refine]);
+
+  return (
+    <MenuWrapper hasItems={items && items.length > 0}>
+      {items.map(item => (
         <RefinementFilter
           {...item}
           {...restProps}
           handleClick={onClickItem}
           includeCount={false}
         />
-      ))
-    }
-  </MenuWrapper>
-);
+      ))}
+    </MenuWrapper>
+  );
+};
 
 Menu.propTypes = {
   items: PropTypes.array.isRequired,


### PR DESCRIPTION
With shallow rendering fixed, clicking a menu item from taste_tests, then clicking the equipment_review toggle item, keeps the taste_test refinement but makes it inaccessible to toggle. The combination of equipment_reviews and a taste_test menu facet presents a query that shows no items. 