### PR TITLE
Revert "CORE-210: If menu is not valid, clear filtered items"

### DIFF
--- a/src/components/Algolia/shared/Menu/index.js
+++ b/src/components/Algolia/shared/Menu/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { connectMenu } from 'react-instantsearch-dom';
@@ -16,29 +16,20 @@ const MenuWrapper = styled.ul`
   }
 `;
 
-const Menu = ({ items, onClickItem, ...restProps }) => {
-  const { currentRefinement, canRefine, refine } = restProps;
-
-  /** If menu is not valid, clear filtered items */
-  useEffect(() => {
-    if (!canRefine && currentRefinement) {
-      refine();
-    }
-  }, [currentRefinement, canRefine, refine]);
-
-  return (
-    <MenuWrapper hasItems={items && items.length > 0}>
-      {items.map(item => (
+const Menu = ({ items, onClickItem, ...restProps }) => (
+  <MenuWrapper hasItems={items && items.length > 0}>
+    {
+      items.map(item => (
         <RefinementFilter
           {...item}
           {...restProps}
           handleClick={onClickItem}
           includeCount={false}
         />
-      ))}
-    </MenuWrapper>
-  );
-};
+      ))
+    }
+  </MenuWrapper>
+);
 
 Menu.propTypes = {
   items: PropTypes.array.isRequired,


### PR DESCRIPTION
Reverts Americastestkitchen/mise-ui#662
It seems like these refinement states only happen when controlling refinement state manually in areas like BrowseInstantSearch. Reverting this so manual refinement state rules are all declared in the same place, and triggering rerenders from the same place