### PR TITLE
homepage add style exports

### DIFF
--- a/src/components/BylineList/BylineList.stories.tsx
+++ b/src/components/BylineList/BylineList.stories.tsx
@@ -34,6 +34,7 @@ export const OneAuthor = () => <Preview props={exampleAuthorsProp.oneAuthor} />;
 export const OneAuthorNoPhoto = () => <Preview props={exampleAuthorsProp.oneAuthorNoPhoto} />;
 export const TwoAuthor = () => <Preview props={exampleAuthorsProp.twoAuthors} />;
 export const ThreeAuthors = () => <Preview props={exampleAuthorsProp.threeAuthors} />;
+export const OneAuthorDisabledStyles = () => <Preview props={exampleAuthorsProp.oneAuthor} />;
 
 // Theming
 export const CCOTheme = () => <Preview theme={{ siteKey: 'cco' }} props={exampleAuthorsProp.oneAuthor} />;

--- a/src/components/BylineList/BylineList.tsx
+++ b/src/components/BylineList/BylineList.tsx
@@ -83,10 +83,11 @@ const Wrapper = styled.span<{ refHeight: number; disableStacked?: boolean }>`
     /* when display direction column, align self */
     align-self: ${props.refHeight < 40 ? 'center' : 'initial'};  
   `)};
+
   ${props => props.disableStacked && css`${cssWrapperInline}`};
 
   /* tablet and above has attribution on its own line. */
-  ${props => !props.disableStacked && cssStackedBreakpoint(css`
+  ${props => (!props.disableStacked) && cssStackedBreakpoint(css`
     ${Attribution} {
       display: block;
       margin: ${spacing.xsm} 0;

--- a/src/components/BylineList/BylineList.tsx
+++ b/src/components/BylineList/BylineList.tsx
@@ -69,17 +69,21 @@ const Attribution = styled.span<{ atLeastOneAuthor: boolean; disableStacked?: bo
     && css`${cssAttributionSeparator}`}
 `;
 
-const cssFnWrapperInline = (refHeight: number) => css`
+const cssWrapperInline = css`
   margin-top: -2px;
   margin-bottom: ${spacing.sm};
   max-width: 28.8rem;
   padding-right: 12px;
-  align-self: ${refHeight < 40 ? 'center' : 'initial'};
+  
 `;
 
 const Wrapper = styled.span<{ refHeight: number; disableStacked?: boolean }>`
-  ${props => !props.disableStacked && cssInlineBreakpoint(css`${cssFnWrapperInline(props.refHeight)}`)};
-  ${props => props.disableStacked && css`${cssFnWrapperInline(props.refHeight)}`};
+  ${props => !props.disableStacked && cssInlineBreakpoint(css`
+    ${cssWrapperInline}
+    /* when display direction column, align self */
+    align-self: ${props.refHeight < 40 ? 'center' : 'initial'};  
+  `)};
+  ${props => props.disableStacked && css`${cssWrapperInline}`};
 
   /* tablet and above has attribution on its own line. */
   ${props => !props.disableStacked && cssStackedBreakpoint(css`

--- a/src/components/BylineList/BylineList.tsx
+++ b/src/components/BylineList/BylineList.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import styled, { css } from 'styled-components';
 import useResizeObserver from 'use-resize-observer/polyfilled';
 import { font, fontSize, spacing } from '../../styles';
@@ -148,6 +148,7 @@ const BylineList = ({
   attribution,
   disableStacked,
 }: BylineListProps): ReactElement => {
+  const [imageError, setImageError] = useState(false);
   const { ref, height = null } = useResizeObserver();
 
   const authorImage = (() => {
@@ -175,13 +176,14 @@ const BylineList = ({
       refHeight={height ?? 0}
       disableStacked={disableStacked}
     >
-      {authorImage && (
+      {(authorImage && !imageError) && (
         <AuthorAvatarImage
           crossOrigin="anonymous"
           decoding="async"
           width={avatarSideLength}
           height={avatarSideLength}
           src={authorImage}
+          onError={() => { setImageError(true); }}
         />
       )}
       <MiddleAlignment>

--- a/src/components/BylineList/BylineList.tsx
+++ b/src/components/BylineList/BylineList.tsx
@@ -44,8 +44,15 @@ const AuthorList = styled.span`
   ${cssThemedColor}
 `;
 
+const cssAttributionSeparator = css`
+  &::before {
+    content: " | ";
+    margin: 0 4px;
+  }
+`;
+
 /** Attribution (i.e. Published on / Updated on) */
-const Attribution = styled.span<{ atLeastOneAuthor: boolean }>`
+const Attribution = styled.span<{ atLeastOneAuthor: boolean; disableStacked?: boolean }>`
   vertical-align: baseline;
   font-family: ${font.pnr};
   font-size: ${fontSize.md};
@@ -54,26 +61,28 @@ const Attribution = styled.span<{ atLeastOneAuthor: boolean }>`
 
   /* tablet and above is divided with | character. If no authors, don't show | character even on desktop. */
   ${props => props.atLeastOneAuthor
-    && cssInlineBreakpoint(css`
-    ${props => props.theme}
-      &::before {
-        content: " | ";
-        margin: 0 4px;
-      }
-    `)}
+    && !props.disableStacked
+    && cssInlineBreakpoint(css`${cssAttributionSeparator}`)}
+
+  ${props => props.atLeastOneAuthor
+    && props.disableStacked
+    && css`${cssAttributionSeparator}`}
 `;
 
-const Wrapper = styled.span<{ refHeight: number }>`
-  ${props => cssInlineBreakpoint(css`
-    margin-top: -2px;
-    margin-bottom: ${spacing.sm};
-    max-width: 28.8rem;
-    padding-right: 12px;
-    align-self: ${props.refHeight < 40 ? 'center' : 'initial'};
-  `)}
+const cssFnWrapperInline = (refHeight: number) => css`
+  margin-top: -2px;
+  margin-bottom: ${spacing.sm};
+  max-width: 28.8rem;
+  padding-right: 12px;
+  align-self: ${refHeight < 40 ? 'center' : 'initial'};
+`;
+
+const Wrapper = styled.span<{ refHeight: number; disableStacked?: boolean }>`
+  ${props => !props.disableStacked && cssInlineBreakpoint(css`${cssFnWrapperInline(props.refHeight)}`)};
+  ${props => props.disableStacked && css`${cssFnWrapperInline(props.refHeight)}`};
 
   /* tablet and above has attribution on its own line. */
-  ${cssStackedBreakpoint(css`
+  ${props => !props.disableStacked && cssStackedBreakpoint(css`
     ${Attribution} {
       display: block;
       margin: ${spacing.xsm} 0;
@@ -125,6 +134,7 @@ export type BylineListProps = {
   onClick?: (id: number) => void;
   authors: Author[];
   attribution: string;
+  disableStacked?: boolean;
 }
 
 /**
@@ -136,6 +146,7 @@ const BylineList = ({
   onClick,
   authors,
   attribution,
+  disableStacked,
 }: BylineListProps): ReactElement => {
   const { ref, height = null } = useResizeObserver();
 
@@ -158,7 +169,12 @@ const BylineList = ({
   const atLeastOneAuthor = authors?.length > 0;
 
   return (
-    <Wrapper className={className} ref={ref} refHeight={height ?? 0}>
+    <Wrapper
+      className={className}
+      ref={ref}
+      refHeight={height ?? 0}
+      disableStacked={disableStacked}
+    >
       {authorImage && (
         <AuthorAvatarImage
           crossOrigin="anonymous"
@@ -173,7 +189,10 @@ const BylineList = ({
           <AuthorListInner authors={authors} onClick={onClick} />
         </AuthorList>
         {attribution && (
-          <Attribution atLeastOneAuthor={atLeastOneAuthor}>
+          <Attribution
+            atLeastOneAuthor={atLeastOneAuthor}
+            disableStacked={disableStacked}
+          >
             {attribution}
           </Attribution>
         )}

--- a/src/components/Cards/ArticleCard/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard/ArticleCard.tsx
@@ -1,0 +1,161 @@
+import React, { PropsWithChildren, ReactNode, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { md, untilMd } from '../../../styles/breakpoints';
+import { color, font } from '../../../styles';
+import { cssThemedColor, cssThemedFontBold } from '../../../styles/mixins';
+import Badge from '../../Badge';
+import cloudinaryInstance, { baseImageConfig } from '../../../lib/cloudinary';
+import Sticker from '../shared/Sticker';
+import BylineList, { Author } from '../../BylineList';
+import { InferStyledTypes } from '../../../styles/utility-types';
+
+/*
+ * Below md image is only set height, above md card is set height.
+ * Below md we want min-content height on card body, above md we center to set card height.
+ */
+
+const Card = styled.a`
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr auto;
+  ${md(css`
+    grid-template-columns: 1fr minmax(432px, 1fr);
+    grid-template-rows: 1fr;
+    height: 272px;
+  `)}
+`;
+
+const CardImage = styled.div`
+  overflow: hidden;
+  ${untilMd(css`
+    height: 190px;
+  `)}
+  img, picture {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+const CardBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 8px;
+  padding: 16px;
+  background-color: ${color.white};
+`;
+
+const Title = styled.h3`
+  ${cssThemedFontBold}
+  ${cssThemedColor}
+  font-size: 23px;
+  line-height: 26px;
+`;
+
+const Description = styled.div`
+  font-family: ${font.mwr};
+  ${cssThemedColor}
+  font-size: 16px;
+  line-height: 26px;
+  ${untilMd(css`
+    display: none;
+  `)}
+`;
+
+const StickerGroup = styled.div`
+  > * {
+    margin-bottom: 0 !important;
+    &:first-child {
+      margin-left: 0 !important;
+    }
+  }
+`;
+
+const BadgePlacement = styled.div`
+  position: absolute;
+  padding: 8px;
+`;
+
+type SplitCardProps = PropsWithChildren<{
+  linkProps: InferStyledTypes<typeof Card>;
+  documentSiteKey: 'atk' | 'cio' | 'cco';
+  picture: ReactNode;
+}>;
+
+function SplitCard({
+  linkProps,
+  documentSiteKey,
+  picture,
+  children,
+}: SplitCardProps) {
+  const [imageError, setImageError] = useState(false);
+
+  return (
+    <Card {...linkProps}>
+      { !imageError ? (
+        <>
+          <CardImage onError={() => setImageError(true)}>
+            {picture}
+          </CardImage>
+          <BadgePlacement>
+            <Badge type={documentSiteKey} fill={color.transparentBlack} />
+          </BadgePlacement>
+        </>
+      ) : null}
+      <CardBody>
+        {children}
+      </CardBody>
+    </Card>
+  );
+}
+
+export type ArticleCardProps = {
+  title: string;
+  description: string;
+  stickers: { text: string, type: string }[];
+  authors: Pick<Author, 'firstName' | 'lastName' | 'photo' | 'id'>[];
+  attribution: string;
+  cloudinaryId: string;
+  documentSiteKey: 'atk' | 'cio' | 'cco';
+  linkProps: InferStyledTypes<typeof Card>;
+}
+
+export default function ArticleCard({
+  title,
+  description,
+  stickers,
+  authors,
+  attribution,
+  cloudinaryId,
+  documentSiteKey,
+  linkProps,
+}: ArticleCardProps) {
+  const src = cloudinaryInstance.url(cloudinaryId, { ...baseImageConfig, height: 190 });
+  const srcLg = cloudinaryInstance.url(cloudinaryId, { ...baseImageConfig, height: 272 });
+
+  return (
+    <SplitCard
+      linkProps={linkProps}
+      documentSiteKey={documentSiteKey}
+      picture={(
+        <picture>
+          <source srcSet={srcLg} media="(min-width: 768px)" />
+          <img src={src} alt="" />
+        </picture>
+      )}
+    >
+      <StickerGroup>
+        {stickers.map(sticker => <Sticker {...sticker} />)}
+      </StickerGroup>
+      <Title>{title}</Title>
+      <Description>{description}</Description>
+      <BylineList
+        authors={authors}
+        attribution={attribution}
+        disableStacked
+      />
+    </SplitCard>
+  );
+}

--- a/src/components/Cards/ArticleCard/index.ts
+++ b/src/components/Cards/ArticleCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ArticleCard';
+export * from './ArticleCard';

--- a/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
+++ b/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
@@ -172,15 +172,6 @@ const Description = styled.p`
   ${withThemes(DekTheme)}
 `;
 
-const Comments = styled.p`
-  align-items: center;
-  color: ${color.white};
-  display: flex;
-  justify-content: center;
-  font: ${fontSize.md} ${font.pnb};
-  line-height: 1;
-`;
-
 type LeadMarqueeCardProps = {
   /**
    * Author Name

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,8 @@ import fonts from './styles/fonts';
 import globalStyle from './styles/global';
 import { color, font, fontSize, mixins, spacing } from './styles';
 
+export * from './styles/mixins';
+
 export { default as DisplayBeltAd } from './components/Ads/DisplayBeltAd';
 export * from './components/Ads/DisplayBeltAd';
 

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,6 @@ export { default as BaseCarousel } from './components/Carousels/BaseCarousel';
 export * from './components/Cards/RelatedRecipeCard';
 export { default as RelatedRecipeCard } from './components/Cards/RelatedRecipeCard';
 
-
 export * from './components/Cards/ArticleCard';
 export { default as ArticleCard } from './components/Cards/ArticleCard';
 

--- a/src/index.js
+++ b/src/index.js
@@ -122,6 +122,9 @@ export { default as BaseCarousel } from './components/Carousels/BaseCarousel';
 export * from './components/Cards/RelatedRecipeCard';
 export { default as RelatedRecipeCard } from './components/Cards/RelatedRecipeCard';
 
+export * from './components/Cards/ArticleCard';
+export { default as ArticleCard } from './components/Cards/ArticleCard';
+
 export {
   Accordion,
   AccordionControl,


### PR DESCRIPTION
- add style exports
- add disable mobile breakpoint style option on BylineList for article card work.
- hide image on error (for old cloudinary authors with missing images that reference by folder and name only)