### PR TITLE
CORE-263: (b7) replace defaultChecked readonly behavior with controlled component

### DIFF
--- a/src/components/Algolia/shared/RefinementFilter/RefinementFilter.js
+++ b/src/components/Algolia/shared/RefinementFilter/RefinementFilter.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
@@ -184,49 +184,51 @@ const RefinementFilter = ({
   refine,
   handleClick,
   value,
-}) => (
-  <>
-    <RefinementFilterLabel
-      altFill={altFill}
-      className={`${attribute}`}
-      data-site-key={value}
-      isRefined={isRefined || (currentRefinement && currentRefinement.length > 0)}
-      onClick={(e) => {
-        if (!isRefined && typeof handleClick === 'function') handleClick(e);
-        if (filterType === 'refinementList') {
-          refine(value);
-        } else if (filterType === 'toggleRefinement') {
-          if (currentRefinement.length > 0) {
-            refine(false);
-          } else {
-            refine(value);
-          }
-        }
-      }}
-    >
-      {
-        isRefined || (filterType === 'toggleRefinement' && currentRefinement.length > 0) ? (
+}) => {
+  /**
+   * @type {(e: React.ChangeEvent<HTMLInputElement>) => void}
+   */
+  const onChange = useCallback((e) => {
+    if (!isRefined && typeof handleClick === 'function') {
+      handleClick(e);
+    }
+    if (filterType === 'refinementList') {
+      refine(value);
+    } else if (filterType === 'toggleRefinement') {
+      if (currentRefinement.length > 0) {
+        refine(false);
+      } else {
+        refine(value);
+      }
+    }
+  }, [currentRefinement?.length, filterType, handleClick, isRefined, refine, value]);
+  return (
+    <>
+      <RefinementFilterLabel
+        altFill={altFill}
+        className={`${attribute}`}
+        data-site-key={value}
+        isRefined={isRefined || (currentRefinement && currentRefinement.length > 0)}
+      >
+        {isRefined || (filterType === 'toggleRefinement' && currentRefinement.length > 0) ? (
           <RefinementFilterCheck data-testid="refinement-filter__checkmark">
             <Checkmark />
           </RefinementFilterCheck>
-        ) : null
-      }
-      <RefinementFilterCheckbox
-        defaultChecked={isRefined}
-        name={label}
-        type="checkbox"
-      />
-      {
-        attribute === 'search_site_list' ? (
+        ) : null}
+        <RefinementFilterCheckbox
+          checked={isRefined}
+          name={label}
+          type="checkbox"
+          onChange={onChange}
+        />
+        {attribute === 'search_site_list' ? (
           <Badge
             className="search-refinement__badge"
             fill={isRefined ? altFill : color.eclipse}
             type={value}
           />
-        ) : null
-      }
-      {
-        includeCount ? (
+        ) : null}
+        {includeCount ? (
           <span className="search-refinement-filter__count">
             <span className="search-refinement-list__label-text">
               {label}
@@ -239,11 +241,11 @@ const RefinementFilter = ({
           <span className="search-refinement-list__label-text">
             {label}
           </span>
-        )
-      }
-    </RefinementFilterLabel>
-  </>
-);
+        )}
+      </RefinementFilterLabel>
+    </>
+  );
+};
 
 RefinementFilter.propTypes = {
   altFill: PropTypes.string,

--- a/src/components/Algolia/shared/RefinementFilter2/index.js
+++ b/src/components/Algolia/shared/RefinementFilter2/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
 import { Checkmark } from '../../../DesignTokens/Icon/svgs';
 import { cssThemedColor } from '../../../../styles/mixins';
-import { color, font, fontSize, mixins, spacing, withThemes } from '../../../../styles';
+import { color, font, fontSize, mixins, withThemes } from '../../../../styles';
 
 const RefinementFilterWrapperTheme = {
   default: css`
@@ -163,22 +163,28 @@ const RefinementFilter = ({
   if (filterType === 'toggleRefinement') {
     isActuallyRefined = currentRefinement.length > 0 && currentRefinement.includes(value);
   }
+
+  /**
+   * @type {(e: React.ChangeEvent<HTMLInputElement>) => void}
+   */
+  const onChange = useCallback((e) => {
+    if (!isActuallyRefined && typeof handleClick === 'function') handleClick(e);
+    if (filterType === 'refinementList') {
+      refine(value);
+    } else if (filterType === 'toggleRefinement') {
+      if (isActuallyRefined) {
+        refine(false);
+      } else {
+        refine(value);
+      }
+    }
+  }, [isActuallyRefined, handleClick, filterType, refine, value]);
+
+  const id = `${attribute}-${label}-filter`;
+
   return (
     <RefinementFilterWrapper
       className="refinement-filter__wrapper"
-      onClick={(e) => {
-        e.preventDefault();
-        if (!isActuallyRefined && typeof handleClick === 'function') handleClick(e);
-        if (filterType === 'refinementList') {
-          refine(value);
-        } else if (filterType === 'toggleRefinement') {
-          if (isActuallyRefined) {
-            refine(false);
-          } else {
-            refine(value);
-          }
-        }
-      }}
     >
       {
         isActuallyRefined ? (
@@ -187,13 +193,19 @@ const RefinementFilter = ({
           </RefinementFilterCheck>
         ) : null
       }
-      <RefinementFilterCheckbox defaultChecked={isActuallyRefined} id={`${attribute}-${value}-filter`} type="checkbox" />
+      <RefinementFilterCheckbox
+        checked={isActuallyRefined}
+        onChange={onChange}
+        id={id}
+        type="checkbox"
+      />
       <RefinementFilterLabel
-        htmlFor={`${attribute}-${value}-filter`}
+        htmlFor={id}
         isRefined={isActuallyRefined}
       >
         {label}{includeCount && count ? <RefinementFilterCount>{` (${count})`}</RefinementFilterCount> : null}
       </RefinementFilterLabel>
+
     </RefinementFilterWrapper>
   );
 };

--- a/src/components/Algolia/shared/SortBy/index.js
+++ b/src/components/Algolia/shared/SortBy/index.js
@@ -220,7 +220,7 @@ const SearchSortByLabel = styled.label.attrs({
   className: 'search-sort-by__label',
 })`${withThemes(SearchSortByLabelTheme)}`;
 
-export const CustomSortBy = ({ defaultRefinement, items, refine }) => (
+export const CustomSortBy = ({ items, refine }) => (
   <>
     {
       items.map(({ isRefined, label, isNew, value }) => (
@@ -239,10 +239,10 @@ export const CustomSortBy = ({ defaultRefinement, items, refine }) => (
           </SearchSortByLabel>
           <SearchSortByRadioInput
             className={isRefined ? 'refined' : ''}
-            defaultChecked={value.includes(defaultRefinement)}
+            checked={isRefined}
             id={value}
             name="sortby"
-            onClick={() => {
+            onChange={() => {
               refine(value);
             }}
             type="radio"
@@ -255,9 +255,15 @@ export const CustomSortBy = ({ defaultRefinement, items, refine }) => (
 );
 
 CustomSortBy.propTypes = {
-  defaultRefinement: PropTypes.string.isRequired,
   items: PropTypes.array.isRequired,
   refine: PropTypes.func.isRequired,
 };
 
-export default connectSortBy(CustomSortBy);
+const SortBy = connectSortBy(CustomSortBy);
+
+SortBy.propTypes = {
+  defaultRefinement: PropTypes.string.isRequired,
+  items: PropTypes.array.isRequired,
+};
+
+export default SortBy;


### PR DESCRIPTION
defaultChecked seems to be intended for only initial value in uncontrolled components, but is being used here in a way that the default value is being updated like a controlled component. The input still reconciles but the uncontrolled state isn't communicated to screen readers as the same component changing state. It may be the shadowed browser element that isn't reconciled.  