### PR TITLE
Feature PR Recipes Landing

### DIFF
--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -12,10 +12,13 @@ const AccordionWrapper = styled.div.attrs({
   className: 'accordion-content-wrapper',
 })`
   &:focus-within {
-    box-shadow: 0 0 0 2px ${color.focusRing};
+    box-shadow: none !important;
+  }
 
-    > button:focus {
-      outline: none;
+  .accordion-item__button {
+    &:focus {
+      box-shadow: none !important;
+      ${mixins.focusIndicator()}
     }
   }
 

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -44,6 +44,9 @@ const AccordionButtonTheme = {
     padding: 0.2rem ${spacing.xxsm} 0.2rem 0;
     text-transform: uppercase;
     width: 100%;
+    &:focus {
+      ${mixins.focusIndicator()}
+    }
 
     @media(hover: hover) {
       &:hover {
@@ -214,16 +217,14 @@ const AccordionLabelWrapperTheme = {
     align-items: flex-end;
     display: flex;
 
-    ${({ hasIcon }) => (
-    hasIcon ? `
+    ${({ hasIcon }) => (hasIcon && css`
       .show-hide__button-label {
         display: inline-block;
         margin-right: ${spacing.xsm};
         max-width: 11.25rem;
         text-align: left;
       }
-    ` : ''
-  )}
+    `)}
 
     svg {
       flex-shrink: 0;

--- a/src/components/Ads/DisplayBeltAd/DisplayBeltAd.tsx
+++ b/src/components/Ads/DisplayBeltAd/DisplayBeltAd.tsx
@@ -7,6 +7,7 @@ import { md, untilMd } from '../../../styles/breakpoints';
 import { cssThemedColor } from '../../../styles/mixins';
 import useMedia from '../../hooks/useMedia';
 import DetailTriangleRight from '../components/DetailTriangleRight';
+import Layout from '../TrialBeltAd/Layout';
 
 export type HeroImages = {
   mobile: string,
@@ -273,16 +274,18 @@ const DisplayBeltAd = ({
   onClick,
   saleCopy = 'Up to 70% off',
 }: DisplayBeltAdProps) => (
-  <ImageBgWrapper>
-    <DisplayBeltImage backgroundImages={backgroundImages} />
-    <Content>
-      <TextArea>
-        <Headline>{headline}</Headline>
-        <SaleCopy>{saleCopy}</SaleCopy>
-      </TextArea>
-    </Content>
-    <Cta onClick={onClick} href={ctaLink} target="_blank">{ctaCopy}<DetailTriangleRight /></Cta>
-  </ImageBgWrapper>
+  <Layout excludePadding>
+    <ImageBgWrapper>
+      <DisplayBeltImage backgroundImages={backgroundImages} />
+      <Content>
+        <TextArea>
+          <Headline>{headline}</Headline>
+          <SaleCopy>{saleCopy}</SaleCopy>
+        </TextArea>
+      </Content>
+      <Cta onClick={onClick} href={ctaLink} target="_blank">{ctaCopy}<DetailTriangleRight /></Cta>
+    </ImageBgWrapper>
+  </Layout>
 );
 
 export default DisplayBeltAd;

--- a/src/components/Ads/DisplayBeltAd/DisplayBeltAd.tsx
+++ b/src/components/Ads/DisplayBeltAd/DisplayBeltAd.tsx
@@ -5,6 +5,7 @@ import cloudinaryInstance, { baseImageConfig } from '../../../lib/cloudinary';
 import { color, font, fontSize, letterSpacing, mixins, withThemes } from '../../../styles';
 import { md, untilMd } from '../../../styles/breakpoints';
 import { cssThemedColor } from '../../../styles/mixins';
+import { InferStyledTypes } from '../../../styles/utility-types';
 import useMedia from '../../hooks/useMedia';
 import DetailTriangleRight from '../components/DetailTriangleRight';
 import Layout from '../TrialBeltAd/Layout';
@@ -149,7 +150,13 @@ export type DisplayBeltAdProps = {
   /** Onclick fires mixpanel accepted event */
   onClick: () => void;
   /** sale copy  */
-  saleCopy?: string
+  saleCopy?: string;
+  /**
+   * Pass any additional props to the click area. This can be for
+   *  analytics events, accessibility with "aria-label", or any other
+   *  property unseen for future requirements on the anchor tag.
+   */
+  linkProps?: InferStyledTypes<typeof Cta>;
 };
 
 const ImageLeft = styled.img`
@@ -273,6 +280,7 @@ const DisplayBeltAd = ({
   headline = 'Discover favorite cookbooks',
   onClick,
   saleCopy = 'Up to 70% off',
+  linkProps,
 }: DisplayBeltAdProps) => (
   <Layout excludePadding>
     <ImageBgWrapper>
@@ -283,7 +291,7 @@ const DisplayBeltAd = ({
           <SaleCopy>{saleCopy}</SaleCopy>
         </TextArea>
       </Content>
-      <Cta onClick={onClick} href={ctaLink} target="_blank">{ctaCopy}<DetailTriangleRight /></Cta>
+      <Cta onClick={onClick} href={ctaLink} target="_blank" {...linkProps}>{ctaCopy}<DetailTriangleRight /></Cta>
     </ImageBgWrapper>
   </Layout>
 );

--- a/src/components/Ads/TrialBeltAd/Layout.tsx
+++ b/src/components/Ads/TrialBeltAd/Layout.tsx
@@ -7,7 +7,7 @@ import reducedTextSizing from './css/reducedTextSizing';
  * Consolidates all breakpoint specific layout and styles.
  * Any style changes unrelated to theming can be made here.
  */
-const Layout = styled.div<{ reducedTextSizing?: boolean }>`
+const Layout = styled.div<{ excludePadding?: boolean, reducedTextSizing?: boolean }>`
   ${cssThemedLightBackground}
   ${layoutStyles}
   ${reducedTextSizing}
@@ -16,8 +16,7 @@ const Layout = styled.div<{ reducedTextSizing?: boolean }>`
   width: 100vw;
   margin-left: calc((100vw - 100%) / -2);
   margin-right: calc((100vw - 100%) / -2);
-  padding-left: calc((100vw - 100%) / 2);
-  padding-right: calc((100vw - 100%) / 2);
+  ${({ excludePadding }) => (!excludePadding ? 'padding-left: calc((100vw - 100%) / 2); padding-right: calc((100vw - 100%) / 2);' : '')}
 
   display: flex;
   justify-content: center;

--- a/src/components/Ads/TrialBeltAd/css/components.tsx
+++ b/src/components/Ads/TrialBeltAd/css/components.tsx
@@ -1,6 +1,7 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { font, color } from '../../../../styles';
 import { cssThemedColor } from '../../../../styles/mixins';
+import { md, xlg } from '../../../../styles/breakpoints';
 import { cssThemedButton } from './shared';
 
 export const Headline = styled.p`
@@ -15,6 +16,10 @@ export const Description = styled.p`
   font-family: ${font.pnb};
   font-size: 18px;
   line-height: 20px;
+  max-width: 208px;
+
+  ${md(css`max-width: 300px;`)}
+  ${xlg(css`max-width: 100%`)}
 `;
 
 export const TextArea = styled.div`

--- a/src/components/Ads/TrialBeltAd/css/layoutStyles.ts
+++ b/src/components/Ads/TrialBeltAd/css/layoutStyles.ts
@@ -5,10 +5,9 @@ import { cssHorizontalGridAreas, cssVerticalGridAreas } from './shared';
 
 const desktop = '@media only screen and (min-width: 1280px)';
 
-const mobileLayout = css`
+const mobileLayout = css<{ excludePadding?: boolean }>`
   height: 192px;
-  padding-top: 16px;
-  padding-bottom: 16px;
+  ${({ excludePadding }) => (!excludePadding ? 'padding-top: 16px; padding-bottom: 16px;' : '')}
   
   ${ClickArea} {
     ${cssVerticalGridAreas}
@@ -22,10 +21,9 @@ const mobileLayout = css`
   }
 `;
 
-const tabletLayout = css`
+const tabletLayout = css<{ excludePadding?: boolean}>`
   height: 150px;
-  padding-top: 25px;
-  padding-bottom: 25px;
+  ${({ excludePadding }) => (!excludePadding ? 'padding-top: 25px; padding-bottom: 25px;' : '')}
   
   ${ClickArea} {
     ${cssHorizontalGridAreas}

--- a/src/components/Algolia/shared/AccordionRefinementList/index.js
+++ b/src/components/Algolia/shared/AccordionRefinementList/index.js
@@ -1,9 +1,70 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
 import { connectRefinementList } from 'react-instantsearch-dom';
 
 import RefinementList2 from '../RefinementList2';
 import Accordion from '../../../Accordion';
+import { cssThemedHoverColor } from '../../../../styles/mixins';
+import { color, mixins, withThemes } from '../../../../styles';
+
+const StyledAccordionTheme = {
+  atk: css`
+    .accordion-item__button {
+      @media(hover: hover) {
+          &:hover {
+            .accordion-item__icon {
+              svg {
+                fill: ${color.mint};
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+  cco: css`
+    .accordion-item__button {
+      @media(hover: hover) {
+          &:hover {
+            .accordion-item__icon {
+              svg {
+                fill: ${color.denim};
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+  cio: css`
+    .accordion-item__button {
+      @media(hover: hover) {
+          &:hover {
+            .accordion-item__icon {
+              svg {
+                fill: ${color.squirrel};
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+};
+
+const StyledAccordion = styled(Accordion)`
+  .accordion-ref-list__heading,
+  legend {
+    ${cssThemedHoverColor}
+  }
+
+  .accordion-ref-list__heading {
+    max-width: 18rem;
+  }
+
+  ${withThemes(StyledAccordionTheme)}
+`;
 
 const AccordionRefinementList = ({
   attribute,
@@ -15,7 +76,7 @@ const AccordionRefinementList = ({
   ...restProps
 }) => (
   items && items.length > 0 ? (
-    <Accordion
+    <StyledAccordion
       icon={icon}
       iconSize={iconSize}
       label={() => <h3 className="accordion-ref-list__heading">{showHideLabel}</h3>}
@@ -26,7 +87,7 @@ const AccordionRefinementList = ({
         items={items}
         {...restProps}
       />
-    </Accordion>
+    </StyledAccordion>
   ) : null
 );
 

--- a/src/components/Algolia/shared/Menu/index.js
+++ b/src/components/Algolia/shared/Menu/index.js
@@ -23,6 +23,7 @@ const Menu = ({ items, onClickItem, ...restProps }) => (
         <RefinementFilter
           {...item}
           {...restProps}
+          key={item.label}
           handleClick={onClickItem}
           includeCount={false}
         />

--- a/src/components/Algolia/shared/RefinementFilter/RefinementFilter.js
+++ b/src/components/Algolia/shared/RefinementFilter/RefinementFilter.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
@@ -184,49 +184,51 @@ const RefinementFilter = ({
   refine,
   handleClick,
   value,
-}) => (
-  <>
-    <RefinementFilterLabel
-      altFill={altFill}
-      className={`${attribute}`}
-      data-site-key={value}
-      isRefined={isRefined || (currentRefinement && currentRefinement.length > 0)}
-      onClick={(e) => {
-        if (!isRefined && typeof handleClick === 'function') handleClick(e);
-        if (filterType === 'refinementList') {
-          refine(value);
-        } else if (filterType === 'toggleRefinement') {
-          if (currentRefinement.length > 0) {
-            refine(false);
-          } else {
-            refine(value);
-          }
-        }
-      }}
-    >
-      {
-        isRefined || (filterType === 'toggleRefinement' && currentRefinement.length > 0) ? (
+}) => {
+  /**
+   * @type {(e: React.ChangeEvent<HTMLInputElement>) => void}
+   */
+  const onChange = useCallback((e) => {
+    if (!isRefined && typeof handleClick === 'function') {
+      handleClick(e);
+    }
+    if (filterType === 'refinementList') {
+      refine(value);
+    } else if (filterType === 'toggleRefinement') {
+      if (currentRefinement.length > 0) {
+        refine(false);
+      } else {
+        refine(value);
+      }
+    }
+  }, [currentRefinement?.length, filterType, handleClick, isRefined, refine, value]);
+  return (
+    <>
+      <RefinementFilterLabel
+        altFill={altFill}
+        className={`${attribute}`}
+        data-site-key={value}
+        isRefined={isRefined || (currentRefinement && currentRefinement.length > 0)}
+      >
+        {isRefined || (filterType === 'toggleRefinement' && currentRefinement.length > 0) ? (
           <RefinementFilterCheck data-testid="refinement-filter__checkmark">
             <Checkmark />
           </RefinementFilterCheck>
-        ) : null
-      }
-      <RefinementFilterCheckbox
-        defaultChecked={isRefined}
-        name={label}
-        type="checkbox"
-      />
-      {
-        attribute === 'search_site_list' ? (
+        ) : null}
+        <RefinementFilterCheckbox
+          checked={isRefined}
+          name={label}
+          type="checkbox"
+          onChange={onChange}
+        />
+        {attribute === 'search_site_list' ? (
           <Badge
             className="search-refinement__badge"
             fill={isRefined ? altFill : color.eclipse}
             type={value}
           />
-        ) : null
-      }
-      {
-        includeCount ? (
+        ) : null}
+        {includeCount ? (
           <span className="search-refinement-filter__count">
             <span className="search-refinement-list__label-text">
               {label}
@@ -239,11 +241,11 @@ const RefinementFilter = ({
           <span className="search-refinement-list__label-text">
             {label}
           </span>
-        )
-      }
-    </RefinementFilterLabel>
-  </>
-);
+        )}
+      </RefinementFilterLabel>
+    </>
+  );
+};
 
 RefinementFilter.propTypes = {
   altFill: PropTypes.string,

--- a/src/components/Algolia/shared/RefinementFilter2/index.js
+++ b/src/components/Algolia/shared/RefinementFilter2/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
 import { Checkmark } from '../../../DesignTokens/Icon/svgs';
 import { cssThemedColor } from '../../../../styles/mixins';
-import { color, font, fontSize, mixins, spacing, withThemes } from '../../../../styles';
+import { color, font, fontSize, mixins, withThemes } from '../../../../styles';
 
 const RefinementFilterWrapperTheme = {
   default: css`
@@ -163,22 +163,28 @@ const RefinementFilter = ({
   if (filterType === 'toggleRefinement') {
     isActuallyRefined = currentRefinement.length > 0 && currentRefinement.includes(value);
   }
+
+  /**
+   * @type {(e: React.ChangeEvent<HTMLInputElement>) => void}
+   */
+  const onChange = useCallback((e) => {
+    if (!isActuallyRefined && typeof handleClick === 'function') handleClick(e);
+    if (filterType === 'refinementList') {
+      refine(value);
+    } else if (filterType === 'toggleRefinement') {
+      if (isActuallyRefined) {
+        refine(false);
+      } else {
+        refine(value);
+      }
+    }
+  }, [isActuallyRefined, handleClick, filterType, refine, value]);
+
+  const id = `${attribute}-${label}-filter`;
+
   return (
     <RefinementFilterWrapper
       className="refinement-filter__wrapper"
-      onClick={(e) => {
-        e.preventDefault();
-        if (!isActuallyRefined && typeof handleClick === 'function') handleClick(e);
-        if (filterType === 'refinementList') {
-          refine(value);
-        } else if (filterType === 'toggleRefinement') {
-          if (isActuallyRefined) {
-            refine(false);
-          } else {
-            refine(value);
-          }
-        }
-      }}
     >
       {
         isActuallyRefined ? (
@@ -187,13 +193,19 @@ const RefinementFilter = ({
           </RefinementFilterCheck>
         ) : null
       }
-      <RefinementFilterCheckbox defaultChecked={isActuallyRefined} id={`${attribute}-${value}-filter`} type="checkbox" />
+      <RefinementFilterCheckbox
+        checked={isActuallyRefined}
+        onChange={onChange}
+        id={id}
+        type="checkbox"
+      />
       <RefinementFilterLabel
-        htmlFor={`${attribute}-${value}-filter`}
+        htmlFor={id}
         isRefined={isActuallyRefined}
       >
         {label}{includeCount && count ? <RefinementFilterCount>{` (${count})`}</RefinementFilterCount> : null}
       </RefinementFilterLabel>
+
     </RefinementFilterWrapper>
   );
 };

--- a/src/components/Algolia/shared/RefinementFilter2/index.js
+++ b/src/components/Algolia/shared/RefinementFilter2/index.js
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
 import { Checkmark } from '../../../DesignTokens/Icon/svgs';
+import { cssThemedColor } from '../../../../styles/mixins';
 import { color, font, fontSize, mixins, spacing, withThemes } from '../../../../styles';
 
 const RefinementFilterWrapperTheme = {
   default: css`
     align-items: center;
     display: flex;
+    position: relative;
 
     &:focus-within {
       box-shadow: none !important;
@@ -82,7 +84,6 @@ const RefinementFilterLabel = styled.label.attrs({
 
 const RefinementFilterCountTheme = {
   default: css`
-    color: ${color.nobel};
     font: ${fontSize.md}/1.38 ${font.pnr};
   `,
   dark: css`
@@ -92,14 +93,17 @@ const RefinementFilterCountTheme = {
 
 const RefinementFilterCount = styled.span.attrs({
   className: 'refinement-filter__count',
-})`${withThemes(RefinementFilterCountTheme)}`;
+})`
+  ${cssThemedColor}
+  ${withThemes(RefinementFilterCountTheme)}
+`;
 
 const RefinementFilterCheckTheme = {
   default: css`
     height: 1.2rem;
-    margin-left: -2rem;
-    margin-right: ${spacing.xsm};
-    position: relative;
+    left: -2rem;
+    position: absolute;
+    top: 1rem;
     width: 1.2rem;
 
     svg {

--- a/src/components/Algolia/shared/SortBy/index.js
+++ b/src/components/Algolia/shared/SortBy/index.js
@@ -220,7 +220,7 @@ const SearchSortByLabel = styled.label.attrs({
   className: 'search-sort-by__label',
 })`${withThemes(SearchSortByLabelTheme)}`;
 
-export const CustomSortBy = ({ defaultRefinement, items, refine }) => (
+export const CustomSortBy = ({ items, refine }) => (
   <>
     {
       items.map(({ isRefined, label, isNew, value }) => (
@@ -239,10 +239,10 @@ export const CustomSortBy = ({ defaultRefinement, items, refine }) => (
           </SearchSortByLabel>
           <SearchSortByRadioInput
             className={isRefined ? 'refined' : ''}
-            defaultChecked={value.includes(defaultRefinement)}
+            checked={isRefined}
             id={value}
             name="sortby"
-            onClick={() => {
+            onChange={() => {
               refine(value);
             }}
             type="radio"
@@ -255,9 +255,15 @@ export const CustomSortBy = ({ defaultRefinement, items, refine }) => (
 );
 
 CustomSortBy.propTypes = {
-  defaultRefinement: PropTypes.string.isRequired,
   items: PropTypes.array.isRequired,
   refine: PropTypes.func.isRequired,
 };
 
-export default connectSortBy(CustomSortBy);
+const SortBy = connectSortBy(CustomSortBy);
+
+SortBy.propTypes = {
+  defaultRefinement: PropTypes.string.isRequired,
+  items: PropTypes.array.isRequired,
+};
+
+export default SortBy;

--- a/src/components/Algolia/shared/ToggleRefinement/index.js
+++ b/src/components/Algolia/shared/ToggleRefinement/index.js
@@ -23,6 +23,10 @@ const ToggleRefinementWrapper = styled.div`
       }
     }
   }
+  
+  .refinement-filter__checkmark {
+    top: 0.4rem;
+  }
 `;
 
 const ToggleRefinement = ({

--- a/src/components/Buttons/Button/index.tsx
+++ b/src/components/Buttons/Button/index.tsx
@@ -7,6 +7,7 @@ import {
   fontSize,
   letterSpacing,
   lineHeight,
+  mixins,
   spacing,
   withThemes,
 } from '../../../styles';
@@ -26,6 +27,9 @@ const StyledButtonTheme = {
     text-transform: uppercase;
     transition: 0.2s all ease;
     white-space: nowrap;
+    &:focus {
+      ${mixins.focusIndicator()}
+    }
 
     @media(hover: hover) {
       &:hover {

--- a/src/components/BylineList/BylineList.stories.tsx
+++ b/src/components/BylineList/BylineList.stories.tsx
@@ -1,69 +1,40 @@
 import React from 'react';
-import styled, { css, ThemeProvider } from 'styled-components';
-import type { ComponentMeta } from '@storybook/react';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { action } from '@storybook/addon-actions';
-import BylineList, { BylineListProps } from './BylineList';
-import { defaultTheme, setBackground, setViewport, storybookParameters, wrapKnobs } from '../../config/shared.stories';
-import { untilMd, md } from '../../styles/breakpoints';
-import exampleAuthorsProp from './exampleAuthorsProp.stories';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import styled, { css } from 'styled-components';
+import BylineList from './BylineList';
+import { setArgs, setParameters, setTheme, setViewport } from '../../config/shared.stories';
+import args from './exampleAuthorsProp.stories';
+import { md, untilMd } from '../../styles/breakpoints';
 
 export default {
   title: 'Components/BylineList',
   component: BylineList,
-  ...storybookParameters,
 } as ComponentMeta<typeof BylineList>;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type PreviewProps = { theme?: any, props?: Partial<BylineListProps> };
-
-const defaultArgs: Partial<BylineListProps> = {
-  attribution: 'Updated on Jun. 2020',
-  authors: [],
-};
-
-const Preview = ({ theme, props }: PreviewProps) => (
-  <ThemeProvider theme={{ ...defaultTheme, ...theme }}>
-    <BylineList {...wrapKnobs({ ...defaultArgs, ...props })} />
-  </ThemeProvider>
-);
+const Template: ComponentStory<typeof BylineList> = props => <BylineList {...props} />;
 
 // Author Handling
-export const NoAuthor = () => <Preview />;
-export const OneAuthor = () => <Preview props={exampleAuthorsProp.oneAuthor} />;
-export const OneAuthorNoPhoto = () => <Preview props={exampleAuthorsProp.oneAuthorNoPhoto} />;
-export const TwoAuthor = () => <Preview props={exampleAuthorsProp.twoAuthors} />;
-export const ThreeAuthors = () => <Preview props={exampleAuthorsProp.threeAuthors} />;
+export const NoAuthor = Template.bind({});
+export const OneAuthor = Template.bind({});
+export const OneAuthorNoPhoto = Template.bind({});
+export const TwoAuthor = Template.bind({});
+export const ThreeAuthors = Template.bind({});
 
 // Theming
-export const CCOTheme = () => <Preview theme={{ siteKey: 'cco' }} props={exampleAuthorsProp.oneAuthor} />;
-setBackground('cco', CCOTheme);
-export const CIOTheme = () => <Preview theme={{ siteKey: 'cio' }} props={exampleAuthorsProp.oneAuthor} />;
-setBackground('cio', CIOTheme);
+export const CCOTheme = Template.bind({});
+export const CIOTheme = Template.bind({});
 
 // Viewport Styles
-export const NoAuthorMobile = () => <Preview />;
-export const OneAuthorMobile = () => <Preview props={exampleAuthorsProp.oneAuthor} />;
-export const OneAuthorMobileNoPhoto = () => <Preview props={exampleAuthorsProp.oneAuthorNoPhoto} />;
-export const ThreeAuthorsMobile = () => <Preview props={exampleAuthorsProp.threeAuthors} />;
-setViewport('iphone5', NoAuthorMobile, OneAuthorMobile, OneAuthorMobileNoPhoto, ThreeAuthorsMobile);
+export const NoAuthorMobile = Template.bind({});
+export const OneAuthorMobile = Template.bind({});
+export const OneAuthorMobileNoPhoto = Template.bind({});
+export const ThreeAuthorsMobile = Template.bind({});
 
 // Link Styles
-export const PhotoAuthorsClickable = () => (
-  <Preview props={{ ...exampleAuthorsProp.oneAuthor, onClick: action('onClick') }} />
-);
-export const AtkAuthorsClickable = () => (
-  <Preview props={{ ...exampleAuthorsProp.threeAuthors, onClick: action('onClick') }} />
-);
-export const CcoAuthorsClickable = () => (
-  <Preview theme={{ siteKey: 'cco' }} props={{ ...exampleAuthorsProp.threeAuthors, onClick: action('onClick') }} />
-);
-setBackground('cco', CcoAuthorsClickable);
-
-export const CioAuthorsClickable = () => (
-  <Preview theme={{ siteKey: 'cio' }} props={{ ...exampleAuthorsProp.threeAuthors, onClick: action('onClick') }} />
-);
-setBackground('cio', CioAuthorsClickable);
+export const PhotoAuthorsClickable = Template.bind({});
+export const AtkAuthorsClickable = Template.bind({});
+export const CcoAuthorsClickable = Template.bind({});
+export const CioAuthorsClickable = Template.bind({});
 
 const DesktopFlexLayout = styled.div<{width: number}>`
   width: ${props => props.width}px;
@@ -102,22 +73,49 @@ const DetailActionsMock = () => (
   </DetailActionsWrapperMock>
 );
 
-type Preview2Props = { width: number, props: Partial<BylineListProps> };
-const Preview2 = ({ width, props }: Preview2Props) => (
-  <ThemeProvider theme={{ ...defaultTheme }}>
-    <DesktopFlexLayout width={width}>
-      <BylineList {...wrapKnobs({ ...defaultArgs, ...props })} />
-      <DetailActionsMock />
-    </DesktopFlexLayout>
-  </ThemeProvider>
+// Self Alignment behavior
+const Template2: ComponentStory<typeof BylineList> = (props, { parameters }) => (
+  <DesktopFlexLayout width={parameters.width ?? 1_000}>
+    <BylineList {...props} />
+    <DetailActionsMock />
+  </DesktopFlexLayout>
 );
 
-// Self Alignment behavior
-export const AlignPhoto = () => <Preview2 props={exampleAuthorsProp.oneAuthor} width={700} />;
-export const AlignNoPhoto = () => (
-  <Preview2 props={exampleAuthorsProp.oneAuthorNoPhoto} width={700} />
+export const AlignPhoto = Template2.bind({});
+export const AlignNoPhoto = Template2.bind({});
+export const AlignPhotoWrap = Template2.bind({});
+export const AlignNoPhotoWrap = Template2.bind({});
+
+// component args
+setArgs(args.noAuthor,
+  NoAuthor, NoAuthorMobile,
 );
-export const AlignPhotoWrap = () => <Preview2 props={exampleAuthorsProp.oneAuthor} width={500} />;
-export const AlignNoPhotoWrap = () => (
-  <Preview2 props={exampleAuthorsProp.oneAuthorNoPhoto} width={500} />
+setArgs(args.oneAuthor,
+  OneAuthor, OneAuthorMobile, PhotoAuthorsClickable, AlignPhoto, AlignPhotoWrap,
 );
+setArgs(args.oneAuthorNoPhoto,
+  OneAuthorNoPhoto, OneAuthorMobileNoPhoto, AlignNoPhoto, AlignNoPhotoWrap,
+);
+setArgs(args.twoAuthors,
+  TwoAuthor,
+);
+setArgs(args.threeAuthors,
+  ThreeAuthors, ThreeAuthorsMobile, AtkAuthorsClickable, CcoAuthorsClickable, CioAuthorsClickable,
+);
+
+// arg that triggers click themes
+setArgs({ onClick: () => {} },
+  PhotoAuthorsClickable, AtkAuthorsClickable, CcoAuthorsClickable, CioAuthorsClickable,
+);
+
+// background and provider siteKey
+setTheme('atk', NoAuthor, OneAuthor, OneAuthorNoPhoto, TwoAuthor, ThreeAuthors);
+setTheme('cio', CIOTheme, CioAuthorsClickable);
+setTheme('cco', CCOTheme, CcoAuthorsClickable);
+
+// line-wrapping parameters
+setParameters({ width: 700 }, AlignPhoto, AlignNoPhoto);
+setParameters({ width: 500 }, AlignPhotoWrap, AlignNoPhotoWrap);
+
+// viewport args
+setViewport('iphone5', NoAuthorMobile, OneAuthorMobile, OneAuthorMobileNoPhoto, ThreeAuthorsMobile);

--- a/src/components/BylineList/BylineList.stories.tsx
+++ b/src/components/BylineList/BylineList.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import styled, { css } from 'styled-components';
-import BylineList from './BylineList';
+import BylineList, { BylineListLight } from './BylineList';
 import { setArgs, setParameters, setTheme, setViewport } from '../../config/shared.stories';
 import args from './exampleAuthorsProp.stories';
 import { md, untilMd } from '../../styles/breakpoints';
@@ -12,6 +12,19 @@ export default {
 } as ComponentMeta<typeof BylineList>;
 
 const Template: ComponentStory<typeof BylineList> = props => <BylineList {...props} />;
+
+const DarkBackground = styled.div`
+  background-color: darkblue;
+`;
+
+const TemplateLight: ComponentStory<typeof BylineListLight> = props => (
+  <DarkBackground>
+    <BylineListLight {...props} />
+  </DarkBackground>
+);
+
+// Styled Variants
+export const BylineListLightVariant = TemplateLight.bind({});
 
 // Author Handling
 export const NoAuthor = Template.bind({});
@@ -91,7 +104,8 @@ setArgs(args.noAuthor,
   NoAuthor, NoAuthorMobile,
 );
 setArgs(args.oneAuthor,
-  OneAuthor, OneAuthorMobile, PhotoAuthorsClickable, AlignPhoto, AlignPhotoWrap,
+  BylineListLightVariant, OneAuthor, OneAuthorMobile,
+  PhotoAuthorsClickable, AlignPhoto, AlignPhotoWrap,
 );
 setArgs(args.oneAuthorNoPhoto,
   OneAuthorNoPhoto, OneAuthorMobileNoPhoto, AlignNoPhoto, AlignNoPhotoWrap,
@@ -109,7 +123,7 @@ setArgs({ onClick: () => {} },
 );
 
 // background and provider siteKey
-setTheme('atk', NoAuthor, OneAuthor, OneAuthorNoPhoto, TwoAuthor, ThreeAuthors);
+setTheme('atk', BylineListLightVariant, NoAuthor, OneAuthor, OneAuthorNoPhoto, TwoAuthor, ThreeAuthors);
 setTheme('cio', CIOTheme, CioAuthorsClickable);
 setTheme('cco', CCOTheme, CcoAuthorsClickable);
 

--- a/src/components/BylineList/BylineList.tsx
+++ b/src/components/BylineList/BylineList.tsx
@@ -86,7 +86,9 @@ const Author = styled.span.attrs({ rel: 'author' })<{ underline?: boolean }>`
   ${props => props.underline && cssThemedLink}
 `;
 
-type AuthorListInnerProps = {authors: Author[], onClick?: (id: number, name: string) => void};
+type OnClick = (id: number, name: string) => void;
+
+type AuthorListInnerProps = {authors: Author[], onClick?: OnClick};
 
 const AuthorListInner = ({ authors, onClick }: AuthorListInnerProps) => {
   const fullNames = authors.map(
@@ -122,7 +124,7 @@ const AuthorListInner = ({ authors, onClick }: AuthorListInnerProps) => {
 export type BylineListProps = {
   className?: string;
   /** When defined, add link styles and sends id from author that is active */
-  onClick?: (id: number) => void;
+  onClick?: OnClick;
   authors: Author[];
   attribution: string;
 }

--- a/src/components/BylineList/BylineList.tsx
+++ b/src/components/BylineList/BylineList.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 import useResizeObserver from 'use-resize-observer/polyfilled';
-import { font, fontSize, spacing } from '../../styles';
+import { font, fontSize, spacing, color } from '../../styles';
 import { md, untilMd } from '../../styles/breakpoints';
 import cloudinaryInstance, { baseImageConfig } from '../../lib/cloudinary';
 import { cssThemedColor, cssThemedLink } from '../../styles/mixins';
@@ -183,3 +183,12 @@ const BylineList = ({
 };
 
 export default BylineList;
+
+/**
+ * Light themed version of byline list for usage in cards with dark backgrounds.
+ */
+export const BylineListLight = styled(BylineList)`
+  ${AuthorList}, ${Attribution} {
+    color: ${color.white};
+  }
+`;

--- a/src/components/BylineList/exampleAuthorsProp.stories.ts
+++ b/src/components/BylineList/exampleAuthorsProp.stories.ts
@@ -27,10 +27,11 @@ const authors: BylineListProps['authors'] = [
 ];
 
 const exampleAuthorsProp = {
-  oneAuthor: { authors: [authors[0]] },
-  oneAuthorNoPhoto: { authors: [authors.map(author => ({ ...author, photo: undefined }))[0]] },
-  twoAuthors: { authors: [authors[0], authors[1]] },
-  threeAuthors: { authors },
+  noAuthor: { attribution: 'Updated on Jun. 2020', authors: [] },
+  oneAuthor: { attribution: 'Updated on Jun. 2020', authors: [authors[0]] },
+  oneAuthorNoPhoto: { attribution: 'Updated on Jun. 2020', authors: [authors.map(author => ({ ...author, photo: undefined }))[0]] },
+  twoAuthors: { attribution: 'Updated on Jun. 2020', authors: [authors[0], authors[1]] },
+  threeAuthors: { attribution: 'Updated on Jun. 2020', authors },
 };
 
 export default exampleAuthorsProp;

--- a/src/components/Cards/CategoryCard/iconMap.js
+++ b/src/components/Cards/CategoryCard/iconMap.js
@@ -1,5 +1,5 @@
 import CCORooster from '../../DesignTokens/Icon/svgs/CCORooster';
-import CookbookCollection from '../../DesignTokens/Icon/svgs/CookbookCollection';
+import Cookbook from '../../DesignTokens/Icon/svgs/Cookbook';
 import LandingPlay from '../../DesignTokens/Icon/svgs/LandingPlay';
 import LatestReviews from '../../DesignTokens/Icon/svgs/LatestReviews';
 import RecipeCard from '../../DesignTokens/Icon/svgs/RecipeCardUpdate';
@@ -8,7 +8,7 @@ import ShoppingCart from '../../DesignTokens/Icon/svgs/ShoppingCart';
 import TrendingArrow from '../../DesignTokens/Icon/svgs/TrendingArrow';
 
 const IconMap = {
-  cookbook: CookbookCollection,
+  cookbook: Cookbook,
   latest: LatestReviews,
   play: LandingPlay,
   recipeCard: RecipeCard,

--- a/src/components/Cards/CategoryCard/index.js
+++ b/src/components/Cards/CategoryCard/index.js
@@ -199,6 +199,11 @@ const SvgWrapper = styled.div`
   &.latest, &.cookbook {
     width: 64%;
   }
+  
+  svg {
+    height: 100%;
+    width: 100%;
+  }
 `;
 
 const CategoryCard = ({

--- a/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.stories.js
+++ b/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.stories.js
@@ -31,6 +31,28 @@ export const Default = () => (
   </StoryWrapper>
 );
 
+export const WithFavoritesRibbon = () => (
+  <StoryWrapper className="story-wrapper">
+    <LeadMarqueeCard
+      author={text('Author Name', 'Kevin Pang')}
+      authorImageCloudinaryId={text('Author Image', 'AKO%20Articles/Author_Headshots/staff_kevin_pang')}
+      imageUrl={text('Background Image', 'https://res.cloudinary.com/hksqkdlah/image/upload/ar_1:1,c_fill,dpr_2.0,f_auto,fl_lossy,g_faces:auto,h_440,w_792,q_auto:low/22391_sfs-chocolate-crinkle-cookies-35')}
+      backgroundColor={select('Background Color', ['#1A3352', '#B25B18', '#321A52', '#1775C2', '#857351', '#521a2d', '#405700', '#005E71', '#167A7A', '#0B3C3D'], "#005E71")}
+      description={text('Dek', '"There’s a better way than squinting into a laptop."')}
+      displayAttributions
+      commentsCount={300}
+      numRatings={43}
+      avgRating={4.8}
+      displayFavoritesRibbon
+      favoriteObjectId="recipe_8125"
+      href={text('Link', 'https://www.americastestkitchen.com/recipes/8125')}
+      siteKey="atk"
+      stickers={[{ type: 'priority', text: 'New' }, { type: 'editorial', text: 'Dessert' }]}
+      title={text('Title', 'Chocolate Crinkle Cookies')}
+    />
+  </StoryWrapper>
+);
+
 export const NoAuthorImage = () => (
   <StoryWrapper className="story-wrapper">
     <LeadMarqueeCard

--- a/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
+++ b/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
@@ -201,7 +201,7 @@ type LeadMarqueeCardProps = {
   /** Image for card. */
   imageUrl: string;
   href: string;
-  siteKey: 'atk' | 'cco' | 'cio' | 'kids' | 'school' | 'shop'
+  siteKey: 'atk' | 'cco' | 'cio' | 'kids' | 'school' | 'shop';
   /** Optional: attribution controls */
   displayAttributions?: boolean;
   commentsCount?: number;

--- a/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
+++ b/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from 'react';
 import styled, { css } from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
-import { color, font, fontSize, lineHeight, spacing, withThemes } from '../../../styles';
+import { color, font, fontSize, lineHeight, mixins, spacing, withThemes } from '../../../styles';
 import Badge from '../../Badge';
 import Byline from '../../Byline';
 import FavoriteRibbonWithBg from '../shared/FavoriteRibbonWithBg';
@@ -32,6 +32,19 @@ const LeadMarqueeCardWrapper = styled.article.attrs({
     transform: scale(1.1);
   }
 
+  a {
+    overflow: hidden;
+    &:focus {
+      .lead-marquee-card__content {
+        ${mixins.focusIndicator('#ffffff', '18px')}
+      }
+    }
+  }
+  
+  button:focus {
+    ${mixins.focusIndicator('#ffffff', '2px')}
+  }
+
   ${breakpoint('smmd')`
     .lead-marquee-card__image {
       transform: scale(1.05);
@@ -47,6 +60,8 @@ const LeadMarqueeCardWrapper = styled.article.attrs({
   `}
 
   ${breakpoint('xlg')`
+    height: 44rem;
+
     a {
       display: flex;
       max-height: 44rem;
@@ -60,12 +75,14 @@ const LeadMarqueeCardWrapper = styled.article.attrs({
 `;
 
 const MarqueeImageWrapper = styled.div`
+  overflow: hidden;
   position: relative;
 
   ${breakpoint('xlg')`
-    height: 102%;
-    max-width: 79rem;
+    max-width: calc(100% - 34.5rem);
+    width: calc(100% - 34.5rem);
   `}
+
 `;
 
 export const StyledBadge = styled(Badge)`
@@ -86,6 +103,7 @@ const ContentWrapper = styled.div<{ backgroundColor: CSSProperties['backgroundCo
   align-items: center;
   background-color: ${props => props.backgroundColor};
   display: flex;
+  justify-content: center;
   padding: ${spacing.md};
   position: relative;
   z-index: 1;
@@ -105,6 +123,17 @@ const ContentWrapper = styled.div<{ backgroundColor: CSSProperties['backgroundCo
   .user-attributions {
     color: ${color.white};
   }
+
+  .person-head-shot {
+    height: 4rem;
+    margin: 0 0.8rem 0 0;
+    width: 4rem;
+  }
+
+  ${breakpoint('xlg')`
+    min-width: 34.5rem;
+    width: 34.5rem;
+  `}
 `;
 
 export const StickerGroup = styled.div`
@@ -128,9 +157,19 @@ const TitleTheme = {
     font: ${fontSize.xxl}/${lineHeight.sm} ${font.pnb};
     margin-bottom: ${spacing.xsm};
 
+    width; 34rem;
+
+    ${breakpoint('md')`
+      width: 68rem;
+    `}
+
     ${breakpoint('lg')`
-      margin-bottom: ${spacing.sm};
-    `};
+      width: 84.8rem;
+    `}
+
+    ${breakpoint('xlg')`
+      width: 28.8rem;
+    `}
   `,
   cco: css`
     font-family: ${font.clb} !important;
@@ -140,7 +179,7 @@ const TitleTheme = {
   `,
 };
 
-const Title = styled.h1`
+const Title = styled.h2`
   ${withThemes(TitleTheme)}
 `;
 
@@ -156,11 +195,17 @@ const DekTheme = {
     ${breakpoint('md')`
       display: block;
       font: ${fontSize.md}/${lineHeight.lg} ${font.mwr};
-      margin-bottom: ${spacing.sm};
+      margin: 0.4rem 0 ${spacing.sm};
+      max-width: 65.8rem;
     `};
 
     ${breakpoint('lg')`
       line-height: ${lineHeight.md};
+      max-width: 72.4rem;
+    `}
+
+    ${breakpoint('xlg')`
+      max-width: 26.4rem;
     `}
   `,
   cco: css`
@@ -170,15 +215,6 @@ const DekTheme = {
 
 const Description = styled.p`
   ${withThemes(DekTheme)}
-`;
-
-const Comments = styled.p`
-  align-items: center;
-  color: ${color.white};
-  display: flex;
-  justify-content: center;
-  font: ${fontSize.md} ${font.pnb};
-  line-height: 1;
 `;
 
 type LeadMarqueeCardProps = {

--- a/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
+++ b/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
@@ -2,6 +2,7 @@ import React, { CSSProperties } from 'react';
 import styled, { css } from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 import { color, font, fontSize, lineHeight, mixins, spacing, withThemes } from '../../../styles';
+import { untilMd } from '../../../styles/breakpoints';
 import Badge from '../../Badge';
 import Byline from '../../Byline';
 import FavoriteRibbonWithBg from '../shared/FavoriteRibbonWithBg';
@@ -183,6 +184,10 @@ const Title = styled.h2`
   ${withThemes(TitleTheme)}
 `;
 
+const StyledAttributions = styled(FeatureCardUserAttributions)`
+  ${untilMd(css`margin-bottom: 1rem;`)}
+`;
+
 const BylineListSC = styled(BylineList)`
   color: white;
 `;
@@ -317,7 +322,7 @@ const LeadMarqueeCard = ({
           <Title dangerouslySetInnerHTML={{ __html: title }} />
           {
             displayAttributions && (
-              <FeatureCardUserAttributions
+              <StyledAttributions
                 commentsCount={commentsCount}
                 numRatings={numRatings}
                 avgRating={avgRating}

--- a/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
+++ b/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
@@ -8,7 +8,7 @@ import Byline from '../../Byline';
 import FavoriteRibbonWithBg from '../shared/FavoriteRibbonWithBg';
 import Image from '../shared/Image';
 import Sticker from '../shared/Sticker';
-import BylineList, { Author } from '../../BylineList';
+import { Author, BylineListLight } from '../../BylineList';
 import { FeatureCardUserAttributions } from '../shared/UserAttributions/UserAttributions';
 
 const LeadMarqueeCardWrapper = styled.article.attrs({
@@ -158,7 +158,7 @@ const TitleTheme = {
     font: ${fontSize.xxl}/${lineHeight.sm} ${font.pnb};
     margin-bottom: ${spacing.xsm};
 
-    width; 34rem;
+    width: 34rem;
 
     ${breakpoint('md')`
       width: 68rem;
@@ -186,10 +186,6 @@ const Title = styled.h2`
 
 const StyledAttributions = styled(FeatureCardUserAttributions)`
   ${untilMd(css`margin-bottom: 1rem;`)}
-`;
-
-const BylineListSC = styled(BylineList)`
-  color: white;
 `;
 
 const DekTheme = {
@@ -331,7 +327,7 @@ const LeadMarqueeCard = ({
           }
           <Description dangerouslySetInnerHTML={{ __html: description }} />
           {authors.length ? (
-            <BylineListSC authors={authors} attribution="" />
+            <BylineListLight authors={authors} attribution="" />
           ) : author ? (
             <Byline
               author={`By ${author}`}

--- a/src/components/Cards/StandardCard/StandardCard.stories.js
+++ b/src/components/Cards/StandardCard/StandardCard.stories.js
@@ -29,6 +29,10 @@ LoggedIn.args = {
   isFavorited: false,
   searchAttribution: true,
   searchComments: 5,
+  shopPrices: {
+    price: '29.09',
+    salePrice: '10.00',
+  },
   siteKey: 'cio',
   siteKeyFavorites: 'cio',
   stickers: [{ type: 'priority', text: 'New' }, { type: 'editorial', text: 'Trending' }],

--- a/src/components/Cards/shared/Attributions/index.js
+++ b/src/components/Cards/shared/Attributions/index.js
@@ -18,6 +18,10 @@ const StyledAttributions = styled.div`
     display: inline-block;
   }
 
+  ins {
+    font: ${fontSize.md}/${lineHeight.md} ${font.pnb};
+  }
+
   ${breakpoint('xs', 'lg')`
     .attributions__bullet {
       display: none;

--- a/src/components/Cards/shared/CtaLink/index.js
+++ b/src/components/Cards/shared/CtaLink/index.js
@@ -1,22 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import breakpoint from 'styled-components-breakpoint';
 import { color, font, fontSize, lineHeight, mixins, withThemes } from '../../../../styles';
 
 const CtaLinkTheme = {
   default: css`
     color: ${color.tomato};
     transition: color 0.1s ease-in-out;
-    font: 1.2rem/${lineHeight.sm} ${font.pnb};
+    font: ${fontSize.md}/18px ${font.pnb};
 
     &:hover {
       color: ${color.rust};
     }
-
-    ${breakpoint('lg')`
-      font-size: ${fontSize.md};
-    `}
   `,
   dark: css`
     font: ${fontSize.md} /${lineHeight.sm} ${font.pnb};

--- a/src/components/Carousels/BaseCarousel/BaseCarousel.stories.tsx
+++ b/src/components/Carousels/BaseCarousel/BaseCarousel.stories.tsx
@@ -269,6 +269,7 @@ const RecipeCarouselExampleTemplate = ({ siteKey = 'atk' }: ActionProps) => (
         title="Got Gear, Need Recipes?"
         header={(
           <LinkCarouselHeader
+            includeIcon
             title="Got Gear, Need Recipes?"
             linkText="browse all Books"
             linkProps={{ href: '/#' }}

--- a/src/components/Carousels/BaseCarousel/Headers.tsx
+++ b/src/components/Carousels/BaseCarousel/Headers.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import Cookbook from '../../DesignTokens/Icon/svgs/Cookbook';
 import { mixins, font, withThemes, color } from '../../../styles';
-import { Intro, Title, Topic } from './styled-elements';
+import { Intro, Title, TitleWrapper, Topic } from './styled-elements';
 import { cssThemedColor, cssThemedFontAccentColorAlt } from '../../../styles/mixins';
 import { InferStyledTypes } from '../../../styles/utility-types';
 import { ChevronThin } from '../../DesignTokens/Icon';
@@ -27,17 +27,17 @@ const cssThemedStroke = withThemes({
  *  the arrow buttons by a bit to match designs.
  */
 const cssWrappingStyles = css`
-  ${Title} {
+  ${TitleWrapper} {
     display: block;
-    margin-right: -64px; 
-    margin-bottom: 8px;
+    margin-right: -6.4rem; 
+    margin-bottom: 0.8rem;
   }
 `;
 
 const Layout = styled.span<{ hasLink: boolean }>`
   vertical-align: middle;
-  ${Title} {
-    display: inline-block;
+  ${TitleWrapper} {
+    display: inline-flex;
     margin-right: 16px;
   }
   ${({ hasLink }) => hasLink && untilMd(css`${cssWrappingStyles}`)}
@@ -94,14 +94,18 @@ export function LinkCarouselHeader({
 }: LinkCarouselHeaderProps) {
   return (
     <Layout hasLink={!!linkText}>
-      {
-        includeIcon && (
-          <SvgWrapper>
-            <Cookbook fill={color.eclipse} />
-          </SvgWrapper>
-        )
-      }
-      <Title {...titleProps}>{title}</Title>
+      <TitleWrapper>
+        {
+          includeIcon && (
+            <SvgWrapper>
+              <Cookbook fill={color.eclipse} />
+            </SvgWrapper>
+          )
+        }
+        <Title {...titleProps}>
+          {title}
+        </Title>
+      </TitleWrapper>
       {linkText && (
         <Link {...linkProps}>
           {linkText}

--- a/src/components/Carousels/BaseCarousel/Headers.tsx
+++ b/src/components/Carousels/BaseCarousel/Headers.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
+import Cookbook from '../../DesignTokens/Icon/svgs/Cookbook';
 import { mixins, font, withThemes, color } from '../../../styles';
 import { Intro, Title, Topic } from './styled-elements';
 import { cssThemedColor, cssThemedFontAccentColorAlt } from '../../../styles/mixins';
@@ -64,7 +65,20 @@ const Link = styled.a`
   }
 `;
 
+const SvgWrapper = styled.div`
+  height: 1.9rem;
+  display: inline-block;
+  margin-right: 0.8rem;
+  width: 2.6rem;
+
+  svg {
+    max-height: 100%;
+    max-width: 100%;
+  }
+`;
+
 export type LinkCarouselHeaderProps = {
+  includeIcon?: boolean;
   title: string;
   linkText: string;
   titleProps?: InferStyledTypes<typeof Title>;
@@ -72,6 +86,7 @@ export type LinkCarouselHeaderProps = {
 };
 
 export function LinkCarouselHeader({
+  includeIcon,
   title,
   linkText,
   titleProps,
@@ -79,6 +94,13 @@ export function LinkCarouselHeader({
 }: LinkCarouselHeaderProps) {
   return (
     <Layout hasLink={!!linkText}>
+      {
+        includeIcon && (
+          <SvgWrapper>
+            <Cookbook fill={color.eclipse} />
+          </SvgWrapper>
+        )
+      }
       <Title {...titleProps}>{title}</Title>
       {linkText && (
         <Link {...linkProps}>

--- a/src/components/Carousels/BaseCarousel/Headers.tsx
+++ b/src/components/Carousels/BaseCarousel/Headers.tsx
@@ -6,7 +6,7 @@ import { Intro, Title, TitleWrapper, Topic } from './styled-elements';
 import { cssThemedColor, cssThemedFontAccentColorAlt } from '../../../styles/mixins';
 import { InferStyledTypes } from '../../../styles/utility-types';
 import { ChevronThin } from '../../DesignTokens/Icon';
-import { md, untilMd } from '../../../styles/breakpoints';
+import { md, untilSm, untilMd } from '../../../styles/breakpoints';
 
 const cssThemedStrokeAccentAlt = withThemes({
   default: css`stroke: ${color.darkTeal};`,
@@ -29,7 +29,9 @@ const cssThemedStroke = withThemes({
 const cssWrappingStyles = css`
   ${TitleWrapper} {
     margin-bottom: 0.8rem;
-    max-width: 29rem;
+    max-width: 30rem;
+
+    ${untilSm(css`max-width: 26rem;`)}
   }
 `;
 
@@ -48,6 +50,11 @@ const Layout = styled.span<{ hasLink: boolean }>`
 `;
 
 const Link = styled.a`
+  ${untilSm(css`
+    display: block;
+    max-width: 20rem;
+    white-space: pre-wrap;
+  `)}
   white-space: nowrap;
   cursor: pointer;
   text-transform: uppercase;
@@ -70,6 +77,7 @@ const Link = styled.a`
 `;
 
 const SvgWrapper = styled.div`
+  ${untilMd(css`display: none;`)}
   height: 1.9rem;
   display: inline-block;
   margin-right: 0.8rem;

--- a/src/components/Carousels/BaseCarousel/Headers.tsx
+++ b/src/components/Carousels/BaseCarousel/Headers.tsx
@@ -6,7 +6,7 @@ import { Intro, Title, TitleWrapper, Topic } from './styled-elements';
 import { cssThemedColor, cssThemedFontAccentColorAlt } from '../../../styles/mixins';
 import { InferStyledTypes } from '../../../styles/utility-types';
 import { ChevronThin } from '../../DesignTokens/Icon';
-import { untilMd } from '../../../styles/breakpoints';
+import { md, untilMd } from '../../../styles/breakpoints';
 
 const cssThemedStrokeAccentAlt = withThemes({
   default: css`stroke: ${color.darkTeal};`,
@@ -28,18 +28,22 @@ const cssThemedStroke = withThemes({
  */
 const cssWrappingStyles = css`
   ${TitleWrapper} {
-    display: block;
-    margin-right: -6.4rem; 
     margin-bottom: 0.8rem;
+    max-width: 29rem;
   }
 `;
 
 const Layout = styled.span<{ hasLink: boolean }>`
   vertical-align: middle;
+
   ${TitleWrapper} {
     display: inline-flex;
-    margin-right: 16px;
+
+    ${md(css`
+      margin-right: 16px;
+    `)}
   }
+
   ${({ hasLink }) => hasLink && untilMd(css`${cssWrappingStyles}`)}
 `;
 

--- a/src/components/Carousels/BaseCarousel/styled-elements.tsx
+++ b/src/components/Carousels/BaseCarousel/styled-elements.tsx
@@ -88,6 +88,11 @@ export const Header = styled.header`
   padding: 4px 0;
 `;
 
+export const TitleWrapper = styled.div`
+  align-items: center;
+  display: flex; 
+`;
+
 export const Title = styled.h2`
   ${cssThemedColor}
   ${cssThemedFontBold}

--- a/src/components/Carousels/BaseCarousel/styled-elements.tsx
+++ b/src/components/Carousels/BaseCarousel/styled-elements.tsx
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 import { withThemes, color, font } from '../../../styles';
+import { untilSm } from '../../../styles/breakpoints';
 import {
   cssThemedBackground,
   cssThemedBackgroundAccentColorAlt,
@@ -76,6 +77,9 @@ export const Navigation = styled.nav`
   display: flex;
   padding-left: 20px;
   padding-bottom: 4px;
+
+  ${untilSm(css`padding-left: 4px`)}
+
   ${Button}:first-child {
     margin-right: 8px;
   }

--- a/src/components/Carousels/BaseCarousel/styled-elements.tsx
+++ b/src/components/Carousels/BaseCarousel/styled-elements.tsx
@@ -95,13 +95,6 @@ export const Header = styled.header`
 export const TitleWrapper = styled.div`
   align-items: center;
   display: flex; 
-
-  ${untilMd(css`
-    h2 {
-      max-width: 250px;
-      width: 100%;
-    }
-  `)}
 `;
 
 export const Title = styled.h2`

--- a/src/components/Carousels/BaseCarousel/styled-elements.tsx
+++ b/src/components/Carousels/BaseCarousel/styled-elements.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 import { withThemes, color, font } from '../../../styles';
-import { untilSm } from '../../../styles/breakpoints';
+import { untilMd } from '../../../styles/breakpoints';
 import {
   cssThemedBackground,
   cssThemedBackgroundAccentColorAlt,
@@ -73,12 +73,12 @@ export const Svg = styled.svg<{rotated?: boolean}>`
 `;
 
 export const Navigation = styled.nav`
+  ${untilMd(css`padding-left: 8px; padding-bottom: 0;`)}
   flex-shrink: 0;
   display: flex;
   padding-left: 20px;
   padding-bottom: 4px;
 
-  ${untilSm(css`padding-left: 4px`)}
 
   ${Button}:first-child {
     margin-right: 8px;
@@ -95,6 +95,13 @@ export const Header = styled.header`
 export const TitleWrapper = styled.div`
   align-items: center;
   display: flex; 
+
+  ${untilMd(css`
+    h2 {
+      max-width: 250px;
+      width: 100%;
+    }
+  `)}
 `;
 
 export const Title = styled.h2`

--- a/src/components/FilterButton/index.js
+++ b/src/components/FilterButton/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { color, font, fontSize, letterSpacing, lineHeight, spacing, withThemes } from '../../styles';
+import { color, font, fontSize, letterSpacing, lineHeight, spacing, withThemes, mixins } from '../../styles';
 import { cssThemedColor } from '../../styles/mixins';
 import Filter from '../DesignTokens/Icon/svgs/Filter';
 
@@ -9,6 +9,9 @@ const StyledFilterButtonTheme = {
   default: css`
     font: ${fontSize.md}/${lineHeight.sm} ${font.pnb};
     padding: ${spacing.xsm};
+    &:focus {
+      ${mixins.focusIndicator()}
+    }
   `,
   kidsSearch: css`
     color: ${color.black};

--- a/src/components/ShowMoreLess/index.js
+++ b/src/components/ShowMoreLess/index.js
@@ -38,42 +38,32 @@ const ShowMoreLessButton = styled.button`
 
 const ShowMoreLess = ({ initialCount, items, id }) => {
   const [hidden, toggleHidden] = useState(true);
-  let initialItems = null;
-  let restItems = null;
-  if (items.length > initialCount) {
-    initialItems = items.slice(0, initialCount);
-    restItems = items.slice(initialCount);
-  }
+  const initialItems = items.slice(0, initialCount);
+  const restItems = items.slice(initialCount);
+
   return (
     <div>
-      {
-        initialItems && restItems ? (
-          <>
-            <ShowMoreLessInitial>
-              {initialItems.map(item => item)}
-            </ShowMoreLessInitial>
-            <ShowMoreLessRest
-              data-testid="show-more-rest-items"
-              hidden={hidden || null}
-              id={`show-hide--${id}`}
-            >
-              {restItems.map(item => item)}
-            </ShowMoreLessRest>
-            <ShowMoreLessButton
-              aria-controls={`show-hide--${id}`}
-              aria-expanded={!hidden}
-              className="show-more-less__button"
-              onClick={() => { toggleHidden(!hidden); }}
-            >
-              {hidden ? '+ Show More' : '- Show Less'}
-            </ShowMoreLessButton>
-          </>
-        ) : (
-          <ul>
-            {items.map(item => item)}
-          </ul>
-        )
-      }
+      <ShowMoreLessInitial>
+        {initialItems.map(item => item)}
+      </ShowMoreLessInitial>
+      <ShowMoreLessRest
+        data-testid="show-more-rest-items"
+        hidden={hidden || null}
+        id={`show-hide--${id}`}
+      >
+        {restItems.map(item => item)}
+      </ShowMoreLessRest>
+      {!!restItems.length && (
+        <ShowMoreLessButton
+          aria-controls={`show-hide--${id}`}
+          aria-expanded={!hidden}
+          className="show-more-less__button"
+          onClick={() => { toggleHidden(!hidden); }}
+          aria-label={hidden ? 'Show More' : 'Show Less'}
+        >
+          {hidden ? '+ Show More' : '- Show Less'}
+        </ShowMoreLessButton>
+      )}
     </div>
   );
 };

--- a/src/components/ShowMoreLess/index.js
+++ b/src/components/ShowMoreLess/index.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
+import { cssThemedColor, cssThemedHoverColor } from '../../styles/mixins';
 import { color, font, spacing, withThemes } from '../../styles';
 
 const ShowMoreLessInitial = styled.ul``;
@@ -9,17 +10,14 @@ const ShowMoreLessRest = styled.ul``;
 
 export const ShowMoreLessButtonTheme = {
   default: css`
-    color: ${color.nobel};
     font: 1.2rem/1 ${font.pnb};
     letter-spacing: 1.2px;
     padding: ${spacing.xsm} 0;
     text-transform: uppercase;
-
-    &:hover {
-      color: ${color.mint};
-    }
   `,
   kidsSearch: css`
+    color: ${color.nobel};
+
     &:hover {
       color: ${color.jade};
     }
@@ -27,6 +25,14 @@ export const ShowMoreLessButtonTheme = {
 };
 
 const ShowMoreLessButton = styled.button`
+  ${cssThemedColor}
+
+  @media(hover: hover) {
+    &:hover {
+      ${cssThemedHoverColor}
+    }
+  }
+
   ${withThemes(ShowMoreLessButtonTheme)}
 `;
 

--- a/src/config/shared.stories.ts
+++ b/src/config/shared.stories.ts
@@ -34,7 +34,17 @@ export const wrapKnobs = (args: any): any => Object.fromEntries(
 
 export const setBackground = (background: string, ...stories: ComponentStory<any>[]): void => {
   stories.forEach((story) => {
-    story.parameters = { ...story.parameters, backgrounds: { default: background } };
+    story.parameters = {
+      ...story.parameters,
+      backgrounds: {
+        default: background,
+        values: [
+          { name: 'atk', value: '#f5f5f5' },
+          { name: 'cco', value: '#ffffff' },
+          { name: 'cio', value: '#fcf9f3' },
+        ],
+      },
+    };
   });
 };
 
@@ -49,4 +59,19 @@ export const setArgs = (args: any, ...stories: ComponentStory<any>[]): void => {
   stories.forEach((story) => {
     story.args = { ...story.args, ...args };
   });
+};
+
+export const setParameters = (parameters: any, ...stories: ComponentStory<any>[]): void => {
+  stories.forEach((story) => {
+    story.parameters = { ...story.parameters, ...parameters };
+  });
+};
+
+/**
+ * Sets the siteKey used in .storybook/preview.js decorators
+ *  (may be confusing if siteKey is also component property)
+ */
+export const setTheme = (siteKey: 'atk' | 'cio' | 'cco', ...stories: ComponentStory<any>[]): void => {
+  setBackground(siteKey, ...stories);
+  setArgs({ siteKey }, ...stories);
 };

--- a/src/styles/breakpoints.ts
+++ b/src/styles/breakpoints.ts
@@ -42,7 +42,7 @@ export const smmd: BreakpointFn = interp => breakpoint('smmd')`${interp}`;
 export const lg: BreakpointFn = interp => breakpoint('lg')`${interp}`;
 export const xlg: BreakpointFn = interp => breakpoint('xlg')`${interp}`;
 
-export const untilSm: BreakpointFn = interp => breakpoint('sm')`${interp}`;
+export const untilSm: BreakpointFn = interp => breakpoint('xs', 'sm')`${interp}`;
 export const untilMd: BreakpointFn = interp => breakpoint('xs', 'md')`${interp}`;
 export const untilSmmd: BreakpointFn = interp => breakpoint('xs', 'smmd')`${interp}`;
 export const untilLg: BreakpointFn = interp => breakpoint('xs', 'lg')`${interp}`;

--- a/src/styles/mixins.js
+++ b/src/styles/mixins.js
@@ -254,6 +254,13 @@ export const cssThemedColor = withThemes({
   cio: css`color: ${color.cork};`,
 });
 
+export const cssThemedHoverColor = withThemes({
+  default: css`color: ${color.mint};`,
+  atk: css`color: ${color.mint};`,
+  cco: css`color: ${color.denim};`,
+  cio: css`color: ${color.squirrel};`,
+});
+
 export const cssThemedFill = withThemes({
   default: css`fill: ${color.eclipse};`,
   atk: css`fill: ${color.eclipse};`,


### PR DESCRIPTION
Feature PR for recipes LP

- CORE-62: updating LeadMarquee card to support ribbons and ratings
- CORE-65: adding option to render a cookbook icon as part of LinkCarouselHeader
- CORE-269 CORE-267 recipes index design/tablet fixes and functionality fixes
- CORE-261: design fixes for recipes browse page
- CORE-260 CORE-269: follow up fixes from QA
- CORE-299: styled byline list needs selectors to new text areas instead of color inheritance.
- fix mismatch onClick type
- add storybook utils
- refactor byline stories
- add light variant to stories
- CORE_264: recipe landing page ad fixes
- CORE-263: (9) DisplayBeltAd open link to aria changes
- CORE-263: (b7) replace defaultChecked readonly behavior with controlled component
- CORE-263: (b7) Reconcile ul when item length is changed by refinements. (b6) Aria added to more less button
- perf: Missing key on connected menu
- CORE-263: add focus indicators
- CORE-269: adjusting styles for carousel link header to accommodate cookbook collection icon
- hide cookbook collection icon on mobile, enable wrapping on carousel header links for small phones
