### PR TITLE
hs CORE 329 6

### DIFF
--- a/src/components/BylineList/BylineList.tsx
+++ b/src/components/BylineList/BylineList.tsx
@@ -1,10 +1,11 @@
-import React, { ReactElement, useState } from 'react';
-import styled, { css } from 'styled-components';
+import React, { ReactElement, useState, useCallback } from 'react';
+import styled, { css, ThemeProvider } from 'styled-components';
 import useResizeObserver from 'use-resize-observer/polyfilled';
+import breakpoint from 'styled-components-breakpoint';
 import { font, fontSize, spacing, color } from '../../styles';
-import { md, untilMd } from '../../styles/breakpoints';
 import cloudinaryInstance, { baseImageConfig } from '../../lib/cloudinary';
 import { cssThemedColor, cssThemedLink } from '../../styles/mixins';
+import { BreakpointFn } from '../../styles/breakpoints';
 
 export type Author = {
   id?: number;
@@ -16,10 +17,10 @@ export type Author = {
 };
 
 /** Stack author names and attribution in mobile. */
-const cssStackedBreakpoint = untilMd;
+const cssStackedBreakpoint: BreakpointFn = interp => breakpoint('xs', 'bylineList')`${interp}`;
 
 /** Inline author names and attribution in tablet and above. */
-const cssInlineBreakpoint = md;
+const cssInlineBreakpoint: BreakpointFn = interp => breakpoint('bylineList')`${interp}`;
 
 /** cloudinary and image tag height & width number for avatar */
 const avatarSideLength = 40;
@@ -140,7 +141,18 @@ export type BylineListProps = {
   onClick?: OnClick;
   authors: Author[];
   attribution: string;
-  disableStacked?: boolean;
+  px?: number;
+}
+
+function useBreakpointTheme(px = 764) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return useCallback((theme: any) => ({
+    ...theme,
+    breakpoints: {
+      ...theme.breakpoints,
+      bylineList: px,
+    },
+  }), [px]);
 }
 
 /**
@@ -152,8 +164,9 @@ const BylineList = ({
   onClick,
   authors,
   attribution,
-  disableStacked,
+  px,
 }: BylineListProps): ReactElement => {
+  const themeFn = useBreakpointTheme(px);
   const [imageError, setImageError] = useState(false);
   const { ref, height = null } = useResizeObserver();
 
@@ -176,13 +189,14 @@ const BylineList = ({
   const atLeastOneAuthor = authors?.length > 0;
 
   return (
-    <Wrapper
-      className={className}
-      ref={ref}
-      refHeight={height ?? 0}
-      disableStacked={disableStacked}
-    >
-      {(authorImage && !imageError) && (
+    <ThemeProvider theme={themeFn}>
+      <Wrapper
+        className={className}
+        ref={ref}
+        refHeight={height ?? 0}
+        disableStacked={false}
+      >
+        {(authorImage && !imageError) && (
         <AuthorAvatarImage
           crossOrigin="anonymous"
           decoding="async"
@@ -191,21 +205,22 @@ const BylineList = ({
           src={authorImage}
           onError={() => { setImageError(true); }}
         />
-      )}
-      <MiddleAlignment>
-        <AuthorList>
-          <AuthorListInner authors={authors} onClick={onClick} />
-        </AuthorList>
-        {attribution && (
+        )}
+        <MiddleAlignment>
+          <AuthorList>
+            <AuthorListInner authors={authors} onClick={onClick} />
+          </AuthorList>
+          {attribution && (
           <Attribution
             atLeastOneAuthor={atLeastOneAuthor}
-            disableStacked={disableStacked}
+            disableStacked={false}
           >
             {attribution}
           </Attribution>
-        )}
-      </MiddleAlignment>
-    </Wrapper>
+          )}
+        </MiddleAlignment>
+      </Wrapper>
+    </ThemeProvider>
   );
 };
 

--- a/src/components/Cards/ArticleCard/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard/ArticleCard.tsx
@@ -164,7 +164,7 @@ export default function ArticleCard({
       <BylineList
         authors={authors}
         attribution={attribution}
-        disableStacked
+        px={390}
       />
     </SplitCard>
   );

--- a/src/components/Cards/ArticleCard/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard/ArticleCard.tsx
@@ -164,7 +164,7 @@ export default function ArticleCard({
       <BylineList
         authors={authors}
         attribution={attribution}
-        px={390}
+        breakpoint={390}
       />
     </SplitCard>
   );

--- a/src/components/Cards/VideoCard/VideoCard.stories.tsx
+++ b/src/components/Cards/VideoCard/VideoCard.stories.tsx
@@ -30,7 +30,7 @@ const relatedDefault: RelatedRecipeCardProps = {
 };
 
 const defaultArgs: VideoCardProps = {
-  isActive: false,
+  headline: 'FROM THE EPISODE',
   title: 'Patatas Panaderas (Spanish Potatoes with Olive Oil and Wine)',
   titleLinkProps: { href: '/episodes/806-shrimp-fast-and-slow' },
   description: `<p><span class="ql-color-#000000">Test cook Keith Dresser shows host Julia Collin Davison 

--- a/src/components/Cards/VideoCard/VideoCard.tsx
+++ b/src/components/Cards/VideoCard/VideoCard.tsx
@@ -91,7 +91,7 @@ const TitleLink = styled.a`
 `;
 
 export type VideoCardProps = PropsWithChildren<{
-  isActive?: boolean;
+  headline: string;
   title: string;
   description: string;
   titleLinkProps: InferStyledTypes<typeof TitleLink>;
@@ -101,7 +101,7 @@ export type VideoCardProps = PropsWithChildren<{
 const VideoCard = ({
   children,
   description,
-  isActive = false,
+  headline,
   title,
   titleLinkProps,
   cardSlot,
@@ -112,7 +112,7 @@ const VideoCard = ({
     </PlayerWrapper>
     <Content>
       <EpisodeDetails>
-        <Headline>{isActive ? 'Now Playing' : 'Up Next'}</Headline>
+        <Headline>{headline}</Headline>
         <TitleLink {...titleLinkProps}>
           <span>{title}</span>
         </TitleLink>

--- a/src/components/HomepageTagline/HomepageTagline.tsx
+++ b/src/components/HomepageTagline/HomepageTagline.tsx
@@ -6,7 +6,7 @@ import { CCOSmallRooster, CIOTagline, CookingPot } from '../DesignTokens/Icon/sv
 
 const iconCopy = {
   atk: [<CookingPot fill="#3d3d3d" />, 'Home of Cook\'s Country, Cook\'s Illustrated, & ATK Kids.'],
-  cco: [<CCOSmallRooster />, 'Food that\'s meant to be shared with friends and family'],
+  cco: [<CCOSmallRooster />, 'Food that\'s meant to be shared with friends and family.'],
   cio: [<CIOTagline />, 'Cook smarter and succeed every time'],
 };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ declare module 'styled-components-breakpoint' {
         ...params: Parameters<typeof css>
     ) => <P extends object>({ theme }: StyledProps<P>) => ReturnType<typeof css>;
 
-    type ThemeBreakpoint = 'xs' | 'sm' | 'smmd' | 'md' | 'lg' | 'xlg';
+    type ThemeBreakpoint = 'xs' | 'sm' | 'smmd' | 'md' | 'lg' | 'xlg' | 'bylineList';
 
     export default function styledBreakpoint(
         gte: ThemeBreakpoint,

--- a/src/styles/breakpoints.ts
+++ b/src/styles/breakpoints.ts
@@ -31,7 +31,7 @@ export default breakpoints;
  *   `)}
  * `;
  */
-type BreakpointFn = <T>(
+export type BreakpointFn = <T>(
   // eslint-disable-next-line @typescript-eslint/ban-types
   interp: Interpolation<ThemedStyledProps<object, T>>
 ) => ReturnType<CSSFunction>


### PR DESCRIPTION
- CORE-385: add period to cco tagline text
- CORE-340: Remove isActive prop for espresso set headlines
- CORE-341: Breakpoint theme setting for article card
- Revert "add disable option for article card" (was messy and is both replaceable with and no longer needed for article card)
