### PR TITLE
hs CORE 329 9

### DIFF
--- a/src/components/BylineList/BylineList.tsx
+++ b/src/components/BylineList/BylineList.tsx
@@ -224,6 +224,7 @@ export const BylineListLight = styled(BylineList)`
  */
 export const BylineListArticleCard = styled(BylineList)`
   ${Wrapper} {
+    margin-bottom: 0;
     align-self: unset;
   }
 `;

--- a/src/components/BylineList/BylineList.tsx
+++ b/src/components/BylineList/BylineList.tsx
@@ -216,3 +216,14 @@ export const BylineListLight = styled(BylineList)`
     color: ${color.white};
   }
 `;
+
+/**
+ * Align self was implemented for self alignment with detail page actions.
+ * In Article card we are in a different flex direction container so we
+ *  are unsetting the property here.
+ */
+export const BylineListArticleCard = styled(BylineList)`
+  ${Wrapper} {
+    align-self: unset;
+  }
+`;

--- a/src/components/Cards/ArticleCard/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard/ArticleCard.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, ReactNode, useState } from 'react';
 import styled, { css } from 'styled-components';
-import { lg, md, untilMd, xlg } from '../../../styles/breakpoints';
+import { lg, md, untilMd, xlg, xxlg } from '../../../styles/breakpoints';
 import { color, font } from '../../../styles';
 import { cssThemedColor, withThemes, cssThemedTextLinkBold } from '../../../styles/mixins';
 import Badge from '../../Badge';
@@ -37,7 +37,7 @@ const Card = styled.a`
     grid-template-columns: 416px auto;
     grid-template-rows: 272px;
   `)}
-  ${xlg(css`
+  ${xxlg(css`
     grid-template-columns: 488px auto;
     grid-template-rows: 272px;
   `)}

--- a/src/components/Cards/ArticleCard/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard/ArticleCard.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, ReactNode, useState } from 'react';
 import styled, { css } from 'styled-components';
-import { lg, md, untilMd, xlg, xxlg } from '../../../styles/breakpoints';
+import { lg, md, untilMd, xxlg } from '../../../styles/breakpoints';
 import { color, font } from '../../../styles';
 import { cssThemedColor, withThemes, cssThemedTextLinkBold } from '../../../styles/mixins';
 import Badge from '../../Badge';

--- a/src/components/Cards/ArticleCard/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard/ArticleCard.tsx
@@ -6,7 +6,7 @@ import { cssThemedColor, withThemes, cssThemedTextLinkBold } from '../../../styl
 import Badge from '../../Badge';
 import cloudinaryInstance, { baseImageConfig } from '../../../lib/cloudinary';
 import Sticker from '../shared/Sticker';
-import BylineList, { Author } from '../../BylineList';
+import { Author, BylineListArticleCard } from '../../BylineList';
 import { InferStyledTypes } from '../../../styles/utility-types';
 
 const cssThemedDescriptionFont = withThemes({
@@ -167,7 +167,7 @@ export default function ArticleCard({
       </StickerGroup>
       <Title>{title}</Title>
       <Description>{description}</Description>
-      <BylineList
+      <BylineListArticleCard
         authors={authors}
         attribution={attribution}
         breakpoint={550}


### PR DESCRIPTION
- CORE-389: Article card alignment fix
- CORE-389: Move breakpoint for 488 image to 1280
- CORE-390: Remove margin bottom for more non-detail alignment
