### PR TITLE
Article Newsletter widgets missing italics in titles

### DIFF
--- a/src/components/Ads/ReviewsAds/ReviewsEmailCapture/index.js
+++ b/src/components/Ads/ReviewsAds/ReviewsEmailCapture/index.js
@@ -331,7 +331,7 @@ const ReviewsEmailCapture = ({
     <AdWrapper success={success} isWide={isWide}>
       <ContentWrapper success={success} isWide={isWide}>
         <MainContent isWide={isWide}>
-          <AdTitle>{title}</AdTitle>
+          <AdTitle dangerouslySetInnerHTML={{ __html: title }} />
           {!success && (
           <AdDescription>{description}</AdDescription>
           )}


### PR DESCRIPTION
### What does this PR do?
Uses `dangerouslySetInnerHTML` to apply article titles to the element since the title string can have `<em>` tags on them. I felt comfortable using this attribute since we are pulling data from the JSON, but if there's a better way you can think of please let me know! This is a PR that should be reviewed in tandem with an espresso update: https://github.com/Americastestkitchen/espresso/pull/3180

### How do I test this PR?
Run espresso and link this branch. You should see italicized titles in the Newsletter component. Test link: https://www-test.americastestkitchen.com/articles/5186-why-shaken-espresso-is-so-dang-delicious

[CONTENT-159](https://bostoncommonpress.atlassian.net/browse/CONTENT-159)