### PR TITLE
content-94 Update to Related Content Card in Mise

### DIFF
--- a/src/components/Cards/RelatedContentCard/RelatedContentCard.stories.tsx
+++ b/src/components/Cards/RelatedContentCard/RelatedContentCard.stories.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
-import { ThemeProvider } from 'styled-components';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import RelatedContentCard, { RelatedContentCardProps } from './RelatedContentCard';
-import { defaultTheme, setBackground, setViewport, storybookParameters, wrapKnobs } from '../../../config/shared.stories';
+import { siteKey } from '../../../config/argTypes';
+import { addThemedWrapper } from '../../../config/decorators';
 
 export default {
   title: 'Components/Cards/RelatedContentCard',
   component: RelatedContentCard,
-  ...storybookParameters,
-};
+  decorators: [addThemedWrapper()],
+  argTypes: { siteKey },
+} as ComponentMeta<typeof RelatedContentCard>;
 
-type PreviewProps = { theme?: Record<string, unknown>, props?: Partial<RelatedContentCardProps> };
+const Template = (args: RelatedContentCardProps) => (
+  <RelatedContentCard {...args} />
+);
 
 const defaultArgs = {
   href: '/',
@@ -17,33 +21,20 @@ const defaultArgs = {
   headline: 'Recipe',
   title: 'Whole Roast Snapper with Citrus Vinaigrette Vinaigrette',
   body: 'To serve up an impressive dish of roasted red snapper, we started by making shallow slashes in the skin to ensure even cooking and seasoning; this step also allowed us to gauge the doneness of the fish easily.',
+  siteKey: 'atk',
 };
 
-const PreviewRelatedContentCard = ({ theme, props }: PreviewProps) => (
-  <ThemeProvider theme={{ ...defaultTheme, ...theme }}>
-    <RelatedContentCard {...wrapKnobs({ ...defaultArgs, ...props })} />
-  </ThemeProvider>
-);
-
-export const AtkNoLink = () => <PreviewRelatedContentCard theme={{ siteKey: 'atk' }} />;
-export const AtkWithoutTextWrap = () => <PreviewRelatedContentCard theme={{ siteKey: 'atk' }} props={{ title: 'short title', body: 'short body' }} />;
-
-export const AtkWithLink = () => <PreviewRelatedContentCard theme={{ siteKey: 'atk' }} props={{ link: 'Save 26% Right Now' }} />;
-export const AtkWithButton = () => <PreviewRelatedContentCard theme={{ siteKey: 'atk' }} props={{ link: 'Save 26% Right Now', withButton: true }} />;
-
-export const CcoNoLink = () => <PreviewRelatedContentCard theme={{ siteKey: 'cco' }} />;
-export const CcoWithLink = () => <PreviewRelatedContentCard theme={{ siteKey: 'cco' }} props={{ link: 'Save 26% Right Now' }} />;
-export const CcoWithButton = () => <PreviewRelatedContentCard theme={{ siteKey: 'cco' }} props={{ link: 'Save 26% Right Now', withButton: true }} />;
-setBackground('cco', CcoNoLink, CcoWithLink, CcoWithButton);
-
-export const CioNoLink = () => <PreviewRelatedContentCard theme={{ siteKey: 'cio' }} />;
-export const CioWithLink = () => <PreviewRelatedContentCard theme={{ siteKey: 'cio' }} props={{ link: 'Save 26% Right Now' }} />;
-export const CioWithButton = () => <PreviewRelatedContentCard theme={{ siteKey: 'cio' }} props={{ link: 'Save 26% Right Now', withButton: true }} />;
-setBackground('cio', CioNoLink, CioWithLink, CioWithButton);
-
-export const MobileNoLink = () => <PreviewRelatedContentCard theme={{ siteKey: 'atk' }} />;
-export const MobileWithLink = () => <PreviewRelatedContentCard theme={{ siteKey: 'atk' }} props={{ link: 'Save 26% Right Now' }} />;
-export const MobileWithButton2Lines = () => <PreviewRelatedContentCard theme={{ siteKey: 'atk' }} props={{ title: 'Toaster Oven Perfection', link: 'Save Now', withButton: true }} />;
-export const MobileWithButton3Lines = () => <PreviewRelatedContentCard theme={{ siteKey: 'atk' }} props={{ title: 'Toaster Oven Perfection — Save 26%', link: 'Save Now', withButton: true }} />;
-export const MobileCioWithLink = () => <PreviewRelatedContentCard theme={{ siteKey: 'cio' }} props={{ link: 'Save 26% Right Now' }} />;
-setViewport('iphone6', MobileNoLink, MobileWithLink, MobileWithButton2Lines, MobileWithButton3Lines, MobileCioWithLink);
+export const withoutLink: ComponentStory<typeof RelatedContentCard> = Template.bind({});
+withoutLink.args = { ...defaultArgs };
+export const withoutTextWrap: ComponentStory<typeof RelatedContentCard> = Template.bind({});
+withoutTextWrap.args = { ...defaultArgs, title: 'short title', body: 'short body' };
+export const withLink: ComponentStory<typeof RelatedContentCard> = Template.bind({});
+withLink.args = { ...defaultArgs, link: 'Save 26% Right Now' };
+export const withButton: ComponentStory<typeof RelatedContentCard> = Template.bind({});
+withButton.args = { ...defaultArgs, link: 'Save 26% Right Now', withButton: true };
+export const withoutImage: ComponentStory<typeof RelatedContentCard> = Template.bind({});
+withoutImage.args = { ...defaultArgs, src: undefined };
+export const withLinkWithoutImage: ComponentStory<typeof RelatedContentCard> = Template.bind({});
+withLinkWithoutImage.args = { ...defaultArgs, link: 'Save 26% Right Now', src: undefined };
+export const withButtonWithoutImage: ComponentStory<typeof RelatedContentCard> = Template.bind({});
+withButtonWithoutImage.args = { ...defaultArgs, link: 'Save 26% Right Now', withButton: true, src: undefined };

--- a/src/components/Cards/RelatedContentCard/RelatedContentCard.tsx
+++ b/src/components/Cards/RelatedContentCard/RelatedContentCard.tsx
@@ -142,36 +142,39 @@ const Card = styled.a`
   })}
 `;
 
-type WideCardWrapperProps = PropsWithChildren<{src: string}> & ComponentProps<typeof Card>
+type WideCardWrapperProps = PropsWithChildren<{ src: string | undefined }> &
+  ComponentProps<typeof Card>;
 
 export function Wrapper({ src, children, ...anchorProps }: WideCardWrapperProps) {
   const theme = useContext(ThemeContext);
   const isMobile = useMedia('(max-width: 767px)');
-  // const base = isMobile ? 145 : 200;
   const offset = theme.siteKey === 'cco' ? -20 : 0;
   const [imageSize, setImageSize] = useState(200);
   useEffect(() => {
-    if (isMobile) {
-      setImageSize(145 + offset);
-    } else {
-      setImageSize(200 + offset);
+    if (src) {
+      if (isMobile) {
+        setImageSize(145 + offset);
+      } else {
+        setImageSize(200 + offset);
+      }
     }
-  }, [isMobile, offset]);
+  }, [isMobile, src, offset]);
 
   return (
     <Card {...anchorProps}>
-      <ImageWrapper>
-        <img
-          width={imageSize}
-          height={imageSize}
-          aria-hidden="true"
-          src={src || undefined}
-          alt=""
-        />
-      </ImageWrapper>
-      <Content>
-        {children}
-      </Content>
+      {/* hide image if one is not provided, content shifts to left */}
+      {src && (
+        <ImageWrapper>
+          <img
+            width={imageSize}
+            height={imageSize}
+            aria-hidden="true"
+            src={src}
+            alt=""
+          />
+        </ImageWrapper>
+      )}
+      <Content>{children}</Content>
     </Card>
   );
 }
@@ -197,7 +200,7 @@ export type RelatedContentCardProps = {
    */
   buttonHref?: string;
   /** Src attribute value for image. */
-  src: string;
+  src?: string;
   /** Text content, 1st at top of card. */
   headline: string;
   /** Text content, 2nd from top of card. */


### PR DESCRIPTION
A featured content component without an image is showing a blank image. The content should shift to the left to adjust for the lack of image. Updated the knobs to use controls instead within Storybook.