### PR TITLE
hs cio homepages qa 1

### DIFF
--- a/src/components/Ads/ReviewsAds/ReviewsEmailCapture/index.js
+++ b/src/components/Ads/ReviewsAds/ReviewsEmailCapture/index.js
@@ -29,7 +29,7 @@ const cssThemedBackground = withThemes({
 const cssThemedBorder = withThemes({
   atk: css`border: solid 1px #D8D8D8;`,
   cco: css`border: solid 1px #E5E5E5;`,
-  cio: css`border: solid 1px #858585;`,
+  cio: css`border: solid 1px #d3c5a0;`,
 });
 
 const AdDescription = styled.p`

--- a/src/components/Cards/FeatureCard/__tests__/FeatureCard.spec.js
+++ b/src/components/Cards/FeatureCard/__tests__/FeatureCard.spec.js
@@ -20,7 +20,7 @@ describe('FeatureCard component should', () => {
           siteKey="cco"
           siteKeyFavorites="cco"
           stickers={[{ type: 'priority', text: 'New' }, { type: 'editorial', text: '28:03' }]}
-          objectId=""
+          objectId="recipe_13333"
           title="Tacos Two Ways"
           href="https://www.americastestkitchen.com/equipment_reviews/1879-plastic-food-storage-containers?ref=new_search_experience_2"
         />

--- a/src/components/Cards/FeatureCard/index.js
+++ b/src/components/Cards/FeatureCard/index.js
@@ -239,7 +239,7 @@ function FeatureCard({
           )}
         </div>
         <StyledBadge className={className} type={siteKey} />
-        {displayFavoritesButton && siteKeyFavorites ? (
+        {displayFavoritesButton && siteKeyFavorites && objectId ? (
           <StyledFavoriteButtonWithBg
             className={className}
             siteKey={siteKeyFavorites}

--- a/src/components/Cards/RelatedRecipeCard/RelatedRecipeCard.tsx
+++ b/src/components/Cards/RelatedRecipeCard/RelatedRecipeCard.tsx
@@ -92,6 +92,7 @@ const RelatedRecipeCard = ({
           avgRating={avgRating}
           commentsCount={commentsCount}
           numRatings={numRatings}
+          hideEmptyAttributions
         />
       </Content>
     </CtaLink>

--- a/src/components/Cards/shared/UserAttributions/UserAttributions.tsx
+++ b/src/components/Cards/shared/UserAttributions/UserAttributions.tsx
@@ -20,17 +20,22 @@ export type UserAttributionsProps = InferStyledTypes<typeof Wrapper> & {
   avgRating?: number;
   numRatings?: number;
   commentsCount?: number;
+  /** When true, will hide rating and comments attributions when they are falsey */
+  hideEmptyAttributions?: boolean;
 };
 
 export default function UserAttributions({
   avgRating,
   numRatings,
   commentsCount,
+  hideEmptyAttributions,
   ...styledProps
 }: UserAttributionsProps) {
   const hasCommentsCount = typeof commentsCount === 'number';
   const hasRatings = typeof avgRating === 'number' && typeof numRatings === 'number';
   const hasNoData = !hasRatings && !hasCommentsCount;
+  const shouldHideRatings = hideEmptyAttributions && (!avgRating || !numRatings);
+  const shouldHideComments = hideEmptyAttributions && !commentsCount;
   const avgRatingRound = hasRatings ? (Math.round(10 * avgRating) / 10).toFixed(1) : undefined;
 
   const ratingsAria = `${avgRating && avgRating > 0 ? `${avgRatingRound} star${avgRatingRound === '1.0' ? '' : 's'} ${numRatings} rating${numRatings === 1 ? '' : 's'}` : ''}`;
@@ -44,12 +49,12 @@ export default function UserAttributions({
       tabIndex={hasNoData ? -1 : 0}
       {...styledProps}
     >
-      {hasRatings && (
+      {hasRatings && !shouldHideRatings && (
         <ActionSummaryItem icon="star">
           <div aria-hidden="true"><strong>{avgRatingRound}</strong>&nbsp;<span>{`(${numRatings})`}</span></div>
         </ActionSummaryItem>
       )}
-      {hasCommentsCount && (
+      {hasCommentsCount && !shouldHideComments && (
         <ActionSummaryItem icon="comment">
           <strong aria-hidden="true">{commentsCount}</strong>
         </ActionSummaryItem>


### PR DESCRIPTION
- CORE-427: Email address field border #d3c5a0
- CORE-435: option to hide user attributions  when empty
- CORE-432: Hide favorites button when no object id (prevent default code gets skipped and we unexpectedly click into documents)
