### PR TITLE
FEA-25: converting PullQuote component and stories to typescript

### DIFF
--- a/src/components/Articles/PullQuote/PullQuote.stories.tsx
+++ b/src/components/Articles/PullQuote/PullQuote.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import PullQuote from './index';
 import { siteKey } from '../../../config/argTypes';
@@ -9,9 +10,9 @@ export default {
   component: PullQuote,
   decorators: [ addThemedWrapper() ],
   argTypes: { siteKey },
-};
+} as ComponentMeta<typeof PullQuote>;
 
-const Template = args => <PullQuote {...args} />;
+const Template: ComponentStory<typeof PullQuote> = props => <PullQuote {...props} />;
 
 const sharedArgs = {
   attribution: 'First Last',

--- a/src/components/Articles/PullQuote/PullQuote.tsx
+++ b/src/components/Articles/PullQuote/PullQuote.tsx
@@ -1,26 +1,25 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import breakpoint from 'styled-components-breakpoint';
 
 import ArticleFigcaption from '../shared/ArticleFigcaption';
+import ArticleComponentWidthType from '../types/ArticleComponentWidth';
 import { Quote } from '../../DesignTokens/Icon/svgs';
 import { color, font, fontSize, mixins, withThemes } from '../../../styles';
+import { md, xlg } from '../../../styles/breakpoints';
 
-const PullQuoteWrapper = styled.div`
+
+const PullQuoteWrapper = styled.div<{ width: ArticleComponentWidthType }>`
   display: flex;
   flex-direction: column;
   margin-bottom: 3rem;
   width: 100%;
 
-  ${breakpoint('md')`
+  ${md(css`
     flex-direction: row;
     max-width: 56rem;
-  `}
+  `)}
 
-  ${breakpoint('xlg')`
-    ${({ width }) => (mixins.articlesWidth(width))}
-  `}
+  ${({ width }) => `${xlg(css`${mixins.articlesWidth(width)}`)}`}
 `;
 
 const PullQuoteIconTheme = {
@@ -35,9 +34,9 @@ const PullQuoteIconTheme = {
       width: 100%;
     }
 
-    ${breakpoint('md')`
+    ${md(css`
       margin-right: 1.6rem;
-    `}
+    `)}
   `,
   atk: css`
     svg {
@@ -70,11 +69,11 @@ const PullQuoteFigure = styled.figure`
   margin: 0;
   padding: 0;
 
-  ${breakpoint('xlg')`
+  ${xlg(css`
     .article-figcaption {
       padding-bottom: 0.8rem;
     }
-  `}
+  `)}
 `;
 
 const PullQuoteBlockQuoteTheme = {
@@ -106,7 +105,19 @@ const PullQuoteBlockQuote = styled.blockquote`
   ${withThemes(PullQuoteBlockQuoteTheme)}
 `;
 
-const PullQuote = ({ attribution, includeIcon, quote, width }) => (
+export type PullQuoteProps = {
+  attribution?: string;
+  includeIcon?: boolean;
+  quote: string;
+  width?: ArticleComponentWidthType;
+};
+
+const PullQuote = ({
+  attribution,
+  includeIcon = true,
+  quote,
+  width = 'default',
+}: PullQuoteProps) => (
   <PullQuoteWrapper className="pull-quote" width={width}>
     {
       includeIcon && (
@@ -130,22 +141,5 @@ const PullQuote = ({ attribution, includeIcon, quote, width }) => (
     </PullQuoteFigure>
   </PullQuoteWrapper>
 );
-
-PullQuote.propTypes = {
-  /** Person attributed with saying the quote */
-  attribution: PropTypes.string,
-  /** Should component render quote icon? */
-  includeIcon: PropTypes.bool,
-  /** Text content of quote */
-  quote: PropTypes.string.isRequired,
-  /** Width configuration for PullQuote */
-  width: PropTypes.oneOf(['default', 'wide']),
-};
-
-PullQuote.defaultProps = {
-  attribution: null,
-  includeIcon: true,
-  width: 'default',
-};
 
 export default PullQuote;

--- a/src/components/Articles/PullQuote/index.ts
+++ b/src/components/Articles/PullQuote/index.ts
@@ -1,0 +1,2 @@
+export { default } from './PullQuote';
+export * from './PullQuote';

--- a/src/components/Articles/types/ArticleComponentWidth.ts
+++ b/src/components/Articles/types/ArticleComponentWidth.ts
@@ -1,0 +1,7 @@
+/*
+ * This type maps to editorial options for article components in barista.
+ * Editors can set any article component's width to 'default' or 'wide'.
+ */
+type ArticleComponentWidthType = 'default' | 'wide';
+
+export default ArticleComponentWidthType;


### PR DESCRIPTION
Converting `PullQuote` article component and its stories to typescript.

Created reusable type `ArticleComponentWidthType` which all article components can pull in as we convert them to typescript. Thoughts on the folder location and whether we want to move it somewhere else?