### PR TITLE
CORE-480: atk homepage a11y screen reader fixes

### DIFF
--- a/src/components/Cards/ArticleCard/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard/ArticleCard.tsx
@@ -71,6 +71,7 @@ const CardBody = styled.div`
   justify-content: center;
   gap: 8px;
   padding: 16px;
+  order: 1;
 `;
 
 const Title = styled.h3`
@@ -126,6 +127,9 @@ function SplitCard({
 
   return (
     <Card data-qa="article-card" {...linkProps}>
+      <CardBody>
+        {children}
+      </CardBody>
       {!imageError ? (
         <Stack>
           <CardImage onError={() => setImageError(true)}>
@@ -134,9 +138,6 @@ function SplitCard({
           {overlay}
         </Stack>
       ) : null}
-      <CardBody>
-        {children}
-      </CardBody>
     </Card>
   );
 }

--- a/src/components/Forms/EmailForm/index.js
+++ b/src/components/Forms/EmailForm/index.js
@@ -200,7 +200,7 @@ const EmailForm = ({
           role="button"
           type="submit"
         >
-          {buttonText}{optionalIcon ? <span>{optionalIcon}</span> : null}
+          {buttonText}{optionalIcon ? <span aria-hidden="true">{optionalIcon}</span> : null}
         </Button>
       </EmailFormElement>
       <HowWeUseWrapper>


### PR DESCRIPTION
* re-order children of ArticleCard so screen reader reads them in the correct order
* hide decoration character from screen reader on form signup button