### PR TITLE
CORE-480: homepage a11y followup

### DIFF
--- a/src/components/Cards/ArticleCard/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard/ArticleCard.tsx
@@ -111,7 +111,7 @@ const FavoritesPlacement = styled.div`
   justify-self: flex-end;
 
   button:focus {
-    ${mixins.focusIndicator()}
+    ${mixins.focusIndicator(color.eclipse, '0')}
   }
 `;
 

--- a/src/components/Cards/shared/Sticker/index.js
+++ b/src/components/Cards/shared/Sticker/index.js
@@ -96,6 +96,7 @@ const Sticker = ({
   type,
 }) => (
   <StyledSticker
+    aria-label={text}
     className={className}
     type={type}
   >

--- a/src/components/Carousels/BaseCarousel/Slides.tsx
+++ b/src/components/Carousels/BaseCarousel/Slides.tsx
@@ -29,7 +29,7 @@ const colorValue = mapSiteString({
 });
 
 const accentValue = mapSiteString({
-  atk: color.mint,
+  atk: color.darkTeal,
   cco: color.denim,
   cio: color.squirrel,
 });


### PR DESCRIPTION
* add aria label to stickers - when sticker values are short words such as 'new' voice over will sometimes read them as acronyms. the sticker is read appropriately when used in the aria label attribute
* reduce offset on focus indicator for favorite ribbons in article cards
* use new atk color contrast color darkTeal for cards in carousels