### PR TITLE
WEB-53: Card Image min-heights for flickity safari

### DIFF
--- a/src/components/Cards/ArticleCard/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard/ArticleCard.tsx
@@ -56,11 +56,13 @@ const CardImage = styled.div`
   overflow: hidden;
   ${untilMd(css`
     height: 190px;
+    min-height: 190px;
   `)}
   img, picture {
     object-fit: cover;
     width: 100%;
     height: 100%;
+    min-height: 272px;
   }
 `;
 

--- a/src/components/Carousels/BaseCarousel/Slides.tsx
+++ b/src/components/Carousels/BaseCarousel/Slides.tsx
@@ -45,6 +45,9 @@ const StandardSlideThemed = styled.div`
         color: ${accentValue} !important;
       }
     }
+    img {
+      min-height: 272px;
+    }
   }
   .action-summary {
     color: ${colorValue} !important;


### PR DESCRIPTION
Issue where flickity on safari isn't correctly resizing uncached images on page load

- Tested on recipes/reviews/homepages