### PR TITLE
web-96: added the updated Focus indicators `Articles` components

### DIFF
--- a/src/components/Articles/ArticleTextBlock/index.js
+++ b/src/components/Articles/ArticleTextBlock/index.js
@@ -6,6 +6,7 @@ import breakpoint from 'styled-components-breakpoint';
 import ArticleTextBlockFloatImage from './components/ArticleTextBlockFloatImage';
 import SidebarCard from '../SidebarCard';
 import { color, font, fontSize, lineHeight, mixins, withThemes } from '../../../styles';
+import { cssThemedLink } from '../../../styles/mixins';
 
 const ArticleTextBlockWrapper = styled.div`
   margin-bottom: 2.4rem;
@@ -101,7 +102,6 @@ const ArticleTextBlockContentTheme = {
   default: css`
     font: ${fontSize.md}/${lineHeight.lg} ${font.mwr};
     margin-bottom: 2.4rem;
-
     > p {
       margin-bottom: 2.4rem;
 
@@ -130,32 +130,21 @@ const ArticleTextBlockContentTheme = {
             padding: 0.6rem 0.8rem 0 0;
           }
         }
-
         ${mixins.articlesWidth('default')}
       }
+    }
+    a {
+      ${cssThemedLink}
     }
   `,
   atk: css`
     color: ${color.eclipse};
-
-    a {
-      ${mixins.styledLink(color.turquoise, color.seaSalt)}
-    }
-
   `,
   cco: css`
     color: ${color.black};
-
-    a {
-      ${mixins.styledLink(color.malibu, color.cornflower)}
-    }
   `,
   cio: css`
     color: ${color.cork};
-
-    a {
-      ${mixins.styledLink(color.dijon, color.sand)}
-    }
   `,
 };
 

--- a/src/components/Articles/FinePrint/FinePrint.stories.js
+++ b/src/components/Articles/FinePrint/FinePrint.stories.js
@@ -18,7 +18,7 @@ const paragraphContent = '<p>What do fried chicken, deli sandwiches, and backyar
 const listContent = '<ul><li>Store 1 bunch basil on counter</li><li>Store 1 bunch each cilantro and thyme on shelf in refrigerator Store 1 bunch each cilantro and thyme on shelf in refrigerator, adding text so this wraps to the next line!</li><li>Store 1 bunch each cilantro and thyme in door of refrigerator</li><li>Knock over (empty) in refrigerator 5 times</li><li>Push off counter (empty) 3 times</li><li>Wash 10 times according to manufacturer instructions</li></ul>';
 const listContentOrdered = `<ol>
   <li>Ordered list has wrap issue <strong>Only When</strong> there is a tag in the list element like bold, it also needs to be long enough to wrap text</li>
-  <li>Ordered list has wrap issue <strong>Only When</strong> there is a tag in the list element like bold, it also needs to be long enough to wrap text</li>
+  <li>Ordered list has wrap issue <a href="#"><strong>Only When</strong></a> there is a tag in the list element like bold, it also needs to be long enough to wrap text</li>
 </ol>`;
 const subtitle = 'There\'s a method to our madness, here\'s our full list of testing.';
 const title = 'Methodology';

--- a/src/components/Articles/FinePrint/FinePrintContent.js
+++ b/src/components/Articles/FinePrint/FinePrintContent.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
 import { color, font, fontSize, mixins, withThemes } from '../../../styles';
+import { cssThemedLink } from '../../../styles/mixins';
 
 const ContentWrapperTheme = {
   default: css`
@@ -11,6 +12,9 @@ const ContentWrapperTheme = {
     margin-bottom: 3rem;
     max-width: 100%;
     padding: 0 0.4rem 2.6rem 1rem;
+    a {
+      ${cssThemedLink}
+    }
 
     ${breakpoint('md')`
       padding: 0.8rem 3.2rem 2.4rem 1.6rem;
@@ -25,26 +29,14 @@ const ContentWrapperTheme = {
   atk: css`
     color: ${color.eclipse};
     ${mixins.articlesBoxLists('atk')}
-
-    a {
-      ${mixins.styledLink(color.turquoise, color.seaSalt)}
-    }
   `,
   cco: css`
     color: ${color.black};
     ${mixins.articlesBoxLists('cco')}
-
-    a {
-      ${mixins.styledLink(color.malibu, color.cornflower)}
-    }
   `,
   cio: css`
     color: ${color.cork};
     ${mixins.articlesBoxLists('cio')}
-
-    a {
-      ${mixins.styledLink(color.dijon, color.sand)}
-    }
   `,
 };
 

--- a/src/components/Articles/LinkFarm/LinkFarm.tsx
+++ b/src/components/Articles/LinkFarm/LinkFarm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { color, font } from '../../../styles';
+import { color, font, mixins } from '../../../styles';
 import { cssThemedColor, cssThemedFontAccentColor } from '../../../styles/mixins';
 
 const Wrapper = styled.div`
@@ -42,6 +42,9 @@ const Anchor = styled.a`
   font-size: 14px;
   font-family: ${font.mwr};
   ${cssThemedFontAccentColor}
+  &:focus, &:active {
+    ${mixins.focusIndicator()};
+  }
 `;
 
 type LinkItem = { id: number; href: string; text: string };

--- a/src/components/Articles/shared/ArticleFigcaption/index.js
+++ b/src/components/Articles/shared/ArticleFigcaption/index.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 
-import { color, font, fontSize, mixins, withThemes } from '../../../../styles';
+import { color, font, fontSize, withThemes } from '../../../../styles';
+import { cssThemedLink } from '../../../../styles/mixins';
 
 const ArticleFigcaptionTheme = {
   default: css`
@@ -36,12 +37,12 @@ const ArticleFigcaptionTheme = {
     }
 
     a {
-      ${mixins.styledLink(color.turquoise, color.seaSalt)}
+      ${cssThemedLink}
     }
   `,
   atk: css`
     a {
-      ${mixins.styledLink(color.turquoise, color.seaSalt)}
+      ${cssThemedLink}
     }
 
     &::after {
@@ -50,7 +51,7 @@ const ArticleFigcaptionTheme = {
   `,
   cco: css`
     a {
-      ${mixins.styledLink(color.malibu, color.cornflower)}
+      ${cssThemedLink}
     }
 
     &::after {
@@ -59,7 +60,7 @@ const ArticleFigcaptionTheme = {
   `,
   cio: css`
     a {
-      ${mixins.styledLink(color.dijon, color.sand)}
+      ${cssThemedLink}
     }
 
     &::after {


### PR DESCRIPTION
**What does this PR do?**
- corrects the Focus indicator styles on the links within the Articles components.
- The solid blue outline on :focus & :active now are using the dotted line design
- can tab between links and focus indicators are all consistent. 