### PR TITLE
web-95: added the updated Focus indicators `Related Content Card` components

### DIFF
--- a/src/components/Cards/RelatedContentCard/RelatedContentCard.tsx
+++ b/src/components/Cards/RelatedContentCard/RelatedContentCard.tsx
@@ -134,6 +134,9 @@ const Content = styled.div`
 const Card = styled.a`
   ${cssCenterLeadingRow}
   background-color: ${color.white};
+  &:focus, &:active {
+    ${mixins.focusIndicator()};
+  }
   ${withThemes({
     cco: css`
       box-sizing: border-box;
@@ -239,7 +242,7 @@ export default function RelatedContentCard({
           {!!link && !!withButton ? (
             <WideCard.AffiliateLink text={link} url={buttonHref || href} />
           ) : (
-            <WideCard.LinkText>{link}</WideCard.LinkText>
+            <WideCard.LinkText href={href}>{link}</WideCard.LinkText>
           )}
         </WideCard.LinkWrapper>
       </ThemeProvider>

--- a/src/components/Cards/shared/AffiliateLink/index.js
+++ b/src/components/Cards/shared/AffiliateLink/index.js
@@ -41,6 +41,9 @@ const AffiliateLinkTheme = {
     text-align: center;
     z-index: 1;
     ${mixins.truncate()}
+    &:focus, &:active {
+      ${mixins.focusIndicator()};
+    }
 
     @media(hover: hover) {
       &:hover {


### PR DESCRIPTION
**What does this PR do?**
- Corrects the Focus indicator styles on the wrapper and inner CTAs of the related Content Cards.
- The solid blue outline on :focus & :active now are using the dotted line design
- Allowed for the CTA Links to be tabbed to
-  Tested both the use of `tabIndex` on the anchor component and the addition of an `href` to the same CTA link component with the Screenreader. I went with the addition of the `href` as it reads the same as the button CTA. The use of `tabIndex` read: "_You are currently on an empty group, inside of a link_". which I felt was more confusing.