### PR TITLE
WEB-102: Issues with screenreader not reading content

### DIFF
--- a/src/components/Articles/ImageList/ImageListContainer/index.js
+++ b/src/components/Articles/ImageList/ImageListContainer/index.js
@@ -7,7 +7,7 @@ import ImageListItem from '../ImageListItem';
 import { color, font, fontSize, mixins, withThemes } from '../../../../styles';
 import { cssThemedColor } from '../../../../styles/mixins';
 
-const ImageListWrapper = styled.aside`
+const ImageListWrapper = styled.div`
   background-color: ${color.white};
   margin: 3rem 0 2.7rem;
   max-width: 100%;

--- a/src/components/Articles/SidebarCard/index.js
+++ b/src/components/Articles/SidebarCard/index.js
@@ -148,7 +148,7 @@ const SidebarCard = ({
   type,
   url,
 }) => (
-  <SidebarCardContainer>
+  <SidebarCardContainer aria-label={`${title} ${type}`}>
     {photo ? (
       <SidebarPicture>
         <source


### PR DESCRIPTION
Change ImageList container from `aside` to `div`
Applies aria-label to sidebar card for better description of complement on tab

* Images without altText will not be focused or read by screen reader
* All valid text and elements can be read on both components using left + right arrows