### PR TITLE
WEB-100 Carousel Focus updates

### DIFF
--- a/src/components/Cards/CategoryCard/index.js
+++ b/src/components/Cards/CategoryCard/index.js
@@ -27,7 +27,7 @@ const LinkToBrowseTheme = {
     }
 
     &:focus {
-      ${mixins.focusIndicator(color.eclipse, '-5px')}
+      ${mixins.focusIndicator(color.eclipse, '-2px')}
     }
 
     ${breakpoint('xlg')`

--- a/src/components/Cards/PersonCard/index.js
+++ b/src/components/Cards/PersonCard/index.js
@@ -18,6 +18,10 @@ const PersonCardWrapperTheme = {
 
     background-color: ${({ mode }) => (mode === 'dark' ? color.smokeyQuartz : color.white)};
 
+    &:focus {
+      ${mixins.focusIndicator(({ mode }) => (mode === 'dark' ? color.white : color.eclipse), '-3px')}
+    }
+
     .person-head-shot {
       margin-bottom: ${spacing.sm};
     }
@@ -57,6 +61,9 @@ const PersonCardDescriptionTheme = {
     text-align: center;
     a {
       ${({ theme }) => (theme?.siteKey ? mixins.styledLinkWithSiteKey(theme.siteKey) : '')}
+      &:focus {
+        ${mixins.focusIndicator(({ mode }) => (mode === 'dark' ? color.white : color.eclipse), '2px')}
+      }
     }
   `,
   atk: css`

--- a/src/components/Cards/RelatedSmallCard/index.js
+++ b/src/components/Cards/RelatedSmallCard/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { cards, color, fontSize, spacing } from '../../../styles';
+import { cards, color, fontSize, spacing, mixins } from '../../../styles';
 import Image from '../shared/Image';
 
 import Title from '../shared/Title';
@@ -30,6 +30,9 @@ const ImageWrapper = styled.div`
 
 const TitleWrapper = styled.a`
   max-width: 17rem;
+  &:focus, &:active {
+    ${mixins.focusIndicator()};
+  }
 
   .no-image & {
     padding-left: ${spacing.xsm};

--- a/src/components/Cards/ReviewableSummaryCard/index.js
+++ b/src/components/Cards/ReviewableSummaryCard/index.js
@@ -93,7 +93,18 @@ const ReviewableSummaryItemTheme = {
 
 const ReviewableSummaryItemEl = styled.div.attrs({
   className: 'reviewable-summary-card',
-})`${withThemes(ReviewableSummaryItemTheme)}`;
+})`
+  ${withThemes(ReviewableSummaryItemTheme)}
+  &:focus {
+    ${mixins.focusIndicator(color.eclipse, '-3px')}
+  }
+  a {
+    margin-bottom: 0.5rem;
+
+    &:focus {
+      ${mixins.focusIndicator(color.eclipse, '0px')}
+    }
+  }`;
 
 const TitleImageWrapper = styled.div.attrs({
   className: 'reviewable-title-image-wrapper',
@@ -151,6 +162,11 @@ const TitleImageWrapper = styled.div.attrs({
 const TitleImageContent = styled.div.attrs({
   className: 'reviewable-title',
 })`
+  a {
+    &:focus, &:active {
+      ${mixins.focusIndicator(color.eclipse, '2px')};
+    }
+  }
   display: flex;
   flex-direction: column;
 

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -86,6 +86,12 @@ const TitleWrapperTheme = {
     align-items: flex-start;
     justify-content: space-between;
     padding-top: ${spacing.xsm};
+
+    a {
+      &:focus, &:active {
+        ${mixins.focusIndicator()};
+      }
+    }
   `,
 };
 

--- a/src/components/Cards/shared/CtaLink/index.js
+++ b/src/components/Cards/shared/CtaLink/index.js
@@ -9,6 +9,10 @@ const CtaLinkTheme = {
     transition: color 0.1s ease-in-out;
     font: ${fontSize.md}/18px ${font.pnb};
 
+    &:focus, &:active {
+      ${mixins.focusIndicator()};
+    }
+
     &:hover {
       color: ${color.rust};
     }

--- a/src/components/Cards/shared/FavoriteButton/index.js
+++ b/src/components/Cards/shared/FavoriteButton/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { color, withThemes } from '../../../../styles';
+import { color, withThemes, mixins } from '../../../../styles';
 import { FavoriteRibbon } from '../../../DesignTokens/Icon';
 
 const StyledFavoriteButtonTheme = {
@@ -14,6 +14,10 @@ const StyledFavoriteButtonTheme = {
     [class*="vertical-line"],
     [class*="horizontal-line"] {
       stroke: transparent;
+    }
+
+    &:focus, &:active {
+      ${mixins.focusIndicator(color.eclipse, '2px')};
     }
 
     @media(hover: hover) {

--- a/src/components/Carousels/BaseCarousel/Headers.tsx
+++ b/src/components/Carousels/BaseCarousel/Headers.tsx
@@ -71,7 +71,7 @@ const Link = styled.a`
     }
   }
   &:focus-within {
-    ${mixins.focusIndicator()}
+    ${mixins.focusIndicator(color.eclipse, '5px')}
   }
 `;
 

--- a/src/components/Carousels/BaseCarousel/styled-elements.tsx
+++ b/src/components/Carousels/BaseCarousel/styled-elements.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
-import { withThemes, color, font } from '../../../styles';
+import { withThemes, color, font, mixins } from '../../../styles';
 import { untilMd } from '../../../styles/breakpoints';
 import {
   cssThemedBackground,
@@ -56,6 +56,10 @@ export const Button = styled.button`
   position: relative;
 
   ${cssThemedBackgroundAccentColorAlt}
+  
+  &:focus, &:active {
+    ${mixins.focusIndicator()};
+  }
 
   &:hover {
     ${cssThemedBackground}
@@ -110,6 +114,11 @@ export const Title = styled.h2`
   font-size: 26px;
   line-height: 33px;
   margin: 0;
+  a {
+    &:focus, &:active {
+        ${mixins.focusIndicator()}     
+      }
+  }
 `;
 
 export const Intro = styled.div`


### PR DESCRIPTION
**What does this PR do?**
_Espresso included a carousel wrapper `CarouselFocusWrapper` that added Focus themes, so the carousels appeared as intended on homepages but not in Articles/guides. Migrated the standalone css settings from Espresso into Mise so that globally, all carousels will have the intended Focus styles and design. This did require updates to several of the component cards that will appear in a carousel. As well as some shared components._
- Headlines for carousels to have updated focus styles if link in headline is present.
- Left and right arrow buttons
- Standard card Link, CTA, and favorites ribbon
- Person Card (light & dark themes)
- Reviewable Summary Item links and CTA
- Category card (set outline offset so match Espresso)