### PR TITLE
chore: convert LoadingRelatedDocumentCard component to TS

### DIFF
--- a/src/components/Cards/LoadingRelatedDocumentCard/LoadingRelatedDocumentCard.stories.tsx
+++ b/src/components/Cards/LoadingRelatedDocumentCard/LoadingRelatedDocumentCard.stories.tsx
@@ -10,7 +10,7 @@ import {
   withThemes,
 } from '../../../styles';
 
-import LoadingRelatedDocumentCard from './index';
+import LoadingRelatedDocumentCard from './LoadingRelatedDocumentCard';
 
 export default {
   title: 'Components/Cards/LoadingCard/RelatedDocumentCard',

--- a/src/components/Cards/LoadingRelatedDocumentCard/LoadingRelatedDocumentCard.stories.tsx
+++ b/src/components/Cards/LoadingRelatedDocumentCard/LoadingRelatedDocumentCard.stories.tsx
@@ -1,12 +1,11 @@
 import breakpoint from 'styled-components-breakpoint';
-import React, { useState } from 'react';
+import React from 'react';
 import styled, { css, ThemeProvider } from 'styled-components';
 import { withKnobs, boolean, select } from '@storybook/addon-knobs';
 
 import {
   breakpoints,
   color,
-  spacing,
   withThemes,
 } from '../../../styles';
 
@@ -28,7 +27,7 @@ const StoryWrapperTheme = {
       width: 848px;
     `}
   `,
-}
+};
 
 const StoryWrapper = styled.div`
   ${withThemes(StoryWrapperTheme)}
@@ -38,11 +37,16 @@ export const Default = () => (
   <ThemeProvider theme={{
     breakpoints,
     siteKey: 'atk',
-  }}>
+  }}
+  >
     <StoryWrapper>
       <LoadingRelatedDocumentCard
-        hasImage={boolean('Has Image')}
-        imageAspectRatio={select('Image Aspect Ratio', ['16:9', '1:1', '16:9'])}
+        hasImage={boolean('Has Image', true)}
+        imageAspectRatio={select(
+          'Image Aspect Ratio',
+          ['16:9', '1:1', '16:9'],
+          '',
+        )}
         siteKey={select('Site Key', ['atk', 'cio', 'cco', 'kids', 'school', 'shop'], 'atk')}
       />
     </StoryWrapper>

--- a/src/components/Cards/LoadingRelatedDocumentCard/LoadingRelatedDocumentCard.tsx
+++ b/src/components/Cards/LoadingRelatedDocumentCard/LoadingRelatedDocumentCard.tsx
@@ -102,7 +102,6 @@ const LoadingRelatedDocumentCard = ({
           type={siteKey}
         />
         <Image
-          // aspectRatio={imageAspectRatio || ''}
           imageAlt="loading-related-img"
           imageUrl={getImageUrl(
             'ATK-S20_20190523_09-46-54_41671_ojahbg',

--- a/src/components/Cards/LoadingRelatedDocumentCard/LoadingRelatedDocumentCard.tsx
+++ b/src/components/Cards/LoadingRelatedDocumentCard/LoadingRelatedDocumentCard.tsx
@@ -1,5 +1,4 @@
 import breakpoint from 'styled-components-breakpoint';
-import PropTypes from 'prop-types';
 import React from 'react';
 import styled, { css } from 'styled-components';
 
@@ -85,11 +84,17 @@ const StyledBadge = styled(Badge)`
   left: ${spacing.xsm};
 `;
 
+type LoadingRelatedDocumentCardProps = {
+  hasImage: boolean
+  imageAspectRatio: string,
+  siteKey: ThemeSiteKey,
+}
+
 const LoadingRelatedDocumentCard = ({
-  hasImage,
+  hasImage = true,
   imageAspectRatio,
   siteKey,
-}) => (
+}: LoadingRelatedDocumentCardProps) => (
   <LoadingRelatedDocumentCardEl>
     {hasImage && (
       <RelatedDocumentImageWrapper>
@@ -97,7 +102,7 @@ const LoadingRelatedDocumentCard = ({
           type={siteKey}
         />
         <Image
-          aspectRatio={imageAspectRatio}
+          // aspectRatio={imageAspectRatio || ''}
           imageAlt="loading-related-img"
           imageUrl={getImageUrl(
             'ATK-S20_20190523_09-46-54_41671_ojahbg',
@@ -117,16 +122,5 @@ const LoadingRelatedDocumentCard = ({
     </LoadingRelatedDocumentCardContent>
   </LoadingRelatedDocumentCardEl>
 );
-
-LoadingRelatedDocumentCard.propTypes = {
-  hasImage: PropTypes.bool,
-  imageAspectRatio: PropTypes.string,
-  siteKey: PropTypes.oneOf(['atk', 'cco', 'cio', 'kids', 'school', 'shop']).isRequired,
-};
-
-LoadingRelatedDocumentCard.defaultProps = {
-  hasImage: true,
-  imageAspectRatio: null,
-};
 
 export default LoadingRelatedDocumentCard;

--- a/src/components/Cards/LoadingRelatedDocumentCard/__tests__/LoadingRelatedDocumentCard.spec.js
+++ b/src/components/Cards/LoadingRelatedDocumentCard/__tests__/LoadingRelatedDocumentCard.spec.js
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import 'jest-styled-components';
 
-import LoadingRelatedDocumentCard from '../index';
+import LoadingRelatedDocumentCard from '../LoadingRelatedDocumentCard';
 import breakpoints from '../../../../styles/breakpoints';
 
 describe('LoadingRelatedDocumentCard component should', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ import LandingEmailAd from './components/Ads/ShowcaseAds/LandingEmailAd';
 import LeadMarqueeCard from './components/Cards/LeadMarqueeCard';
 import LoadingCard from './components/Cards/LoadingCard';
 import LoadingCarousel from './components/Carousels/LoadingCarousel';
-import LoadingRelatedDocumentCard from './components/Cards/LoadingRelatedDocumentCard';
+import LoadingRelatedDocumentCard from './components/Cards/LoadingRelatedDocumentCard/LoadingRelatedDocumentCard';
 import MadeForYouCard from './components/Cards/MadeForYouCard';
 import MadeForYouCarousel from './components/Carousels/MadeForYouCarousel';
 import MarqueeCard from './components/Cards/MarqueeCard';


### PR DESCRIPTION
### What does this PR do?
Converts LoadingRelatedDocumentCard to TS.

### How do I review this PR?
Verify no issue with tests, linting, and props and their defaults are correct. 