### PR TITLE
web-174: updating hover colours from Mint to darkTeal for accessibility

### DIFF
--- a/src/components/SearchInput/index.js
+++ b/src/components/SearchInput/index.js
@@ -225,7 +225,7 @@ const StyledResetButtonTheme = {
     }
 
     &:hover svg g {
-      stroke: ${color.mint};
+      stroke: ${color.darkTeal};
     }
 
     && {


### PR DESCRIPTION
# [WEB-32]([SHORTCUT_LINK](https://bostoncommonpress.atlassian.net/browse/WEB-32))

## What Does This Do?
Changing the hover states or icon color adjustments from #6ba6aa to #437072 for accessibility purposes.
Where necessary, styles removed from Espresso and managed in Mise

### Dependencies (Optional)
- [x] Content Verticals
- [x] Jarvis
- [ ] Kraken
- [x] Espresso
