### PR TITLE
core-582: Issue loading TikTok videos on Firefox ATK, CIO, and CCO

### DIFF
--- a/src/components/MediaEmbed/TikTokEmbed.tsx
+++ b/src/components/MediaEmbed/TikTokEmbed.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import Caption from './Caption';
 import { EmbedProps, useOEmbed } from './utilities';
 
-function useTikTokOEmbed(source: string): { html?: string | undefined; } | undefined {
+function useTikTokOEmbed(source: string): string {
   return useOEmbed({
     baseUrl: 'https://www.tiktok.com/oembed?url=',
     script: 'https://www.tiktok.com/embed.js',
@@ -92,16 +92,16 @@ function useTikTokIframeListener(
 export default function TikTokEmbed({
   source, caption,
 }: EmbedProps) {
+  const embed = useTikTokOEmbed(source);
   const [height, setHeight] = useState<number | undefined>(undefined);
   const ref = useRef<HTMLDivElement>(null);
-  const embed = useTikTokOEmbed(source);
   const iframeSize = useTikTokIframeSize();
   useTikTokIframeListener(ref, setHeight);
 
   return (
     <div>
       <Trim trim={iframeSize} recieved={height}>
-        <Wrapper ref={ref} dangerouslySetInnerHTML={{ __html: embed?.html ?? '' }} />
+        <Wrapper ref={ref} dangerouslySetInnerHTML={{ __html: embed ?? '' }} />
       </Trim>
       <div style={{ width: iframeSize }}>
         <Caption caption={caption} />

--- a/src/components/MediaEmbed/utilities.ts
+++ b/src/components/MediaEmbed/utilities.ts
@@ -1,13 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export type EmbedProps = { source: string; caption?: string };
 
-/**
- * Attach async script tag. Do nothing when src is undefined.
- * @param src script src to load async.
- * @param onLoad Callback when script has finished loading.
- */
-export const useScript = (src?: string, onLoad?: () => void): void => {
+export const useScript = (src: string, onLoad?: () => void): void => {
   useEffect(() => {
     if (!src) return () => {};
     const script = document.createElement('script');
@@ -24,45 +19,34 @@ export const useScript = (src?: string, onLoad?: () => void): void => {
 };
 
 type useOEmbedArgs = {
-  /** The post or video url being requested */
   source: string,
-  /** The base url to request oembeds of the source type */
   baseUrl: string,
-  /** The script to load with the source type */
   script: string;
-  /** A callback to execute when script loads i.e. processesing embeds */
-  onLoad?: () => void
+  onLoad?(): void
 };
 
-/**
- * Fetch OEmbed payload and load scirpt source.
- * @returns OEmbed payload or undefined.
- */
 export const useOEmbed = ({
   source,
   baseUrl,
   script,
-  onLoad,
-}: useOEmbedArgs): { html?: string } | undefined => {
-  useScript(script, onLoad);
-  const isMounted = useRef(true);
-
-  useEffect(() => () => {
-    isMounted.current = false;
-  }, []);
-
-  const [data, setData] = useState<{ html?: string } | undefined>(undefined);
-
+}: useOEmbedArgs) => {
+  const [data, setData] = useState('');
+  useEffect(() => {
+    const scr = document.createElement('script');
+    scr.async = true;
+    scr.src = script;
+    document.body.appendChild(scr);
+    return () => {
+      document.body.removeChild(scr);
+    };
+  });
   useEffect(() => {
     fetch(`${baseUrl}${source}`)
       .then(res => (res.ok ? res.json() : undefined))
       .catch(() => undefined)
       .then((payload) => {
-        if (isMounted.current) {
-          setData(payload);
-        }
+        setData(payload?.html ?? '');
       });
   }, [baseUrl, source]);
-
   return data;
 };


### PR DESCRIPTION
# [CORE-582]([SHORTCUT_LINK](https://bostoncommonpress.atlassian.net/browse/CORE-582))

## What Does This Do?
Allows TikTok to re-render on refresh, and to render in all browsers. 

## To view the bug:
visit: https://mise-ui.netlify.app/?path=/story/components-mediaembed--tik-tok and refresh page, or simply select another story and return to the tiktok embed. iframe does not re-render.

Or view https://www.americastestkitchen.com/articles/5741-the-world-s-easiest-peanut-sauce-has-2-ingredients in Firefox

### Author Tested
- [x] Chrome
- [ ] Edge
- [x] Firefox
- [x] Safari
