### PR TITLE
web-114: add ellipsis if content in the Related Content card

### DIFF
--- a/src/components/Cards/RelatedContentCard/RelatedContentCard.tsx
+++ b/src/components/Cards/RelatedContentCard/RelatedContentCard.tsx
@@ -101,6 +101,7 @@ const Body = styled.span`
     display: none;
   `)}
   margin-bottom: 8px;
+    ${mixins.truncateLineClamp(3)}
 `;
 
 const LinkText = styled.a`


### PR DESCRIPTION
web-114: add ellipsis if content in the Related Content card is too long. 

added the ellipsis and truncated the length to 3 lines.