### PR TITLE
web-93: fix for various printing issues on Articles and Guides. 

### DIFF
--- a/src/components/Articles/ArticleTextBlock/components/ArticleTextBlockFloatImage/index.js
+++ b/src/components/Articles/ArticleTextBlock/components/ArticleTextBlockFloatImage/index.js
@@ -85,6 +85,9 @@ const FloatImageFigure = styled.figure`
 const FloatImageWrapper = styled.div`
   max-width: calc(50% - 0.8rem);
   width: 100%;
+  @media print {
+    page-break-inside: avoid;
+  }
 
   &.no-caption {
     max-width: 100%;

--- a/src/components/Articles/ArticleTextBlock/index.js
+++ b/src/components/Articles/ArticleTextBlock/index.js
@@ -11,6 +11,10 @@ import { cssThemedLink } from '../../../styles/mixins';
 const ArticleTextBlockWrapper = styled.div`
   margin-bottom: 2.4rem;
   width: 100%;
+  display: inline-block;
+  @media print {
+    display: block !important;
+  }
 
   &.article-text-block--box {
     background-color: ${color.white};
@@ -77,6 +81,9 @@ const ArticleTextBlockWrapper = styled.div`
 `;
 
 const ArticleTextBlockCopy = styled.div`
+  @media print {
+    display: block !important;
+  }
   ${breakpoint('xlg')`
     position: relative;
   `}
@@ -156,6 +163,9 @@ const ArticleTextBlockContentTheme = {
 };
 
 const ArticleTextBlockContent = styled.div`
+  @media print {
+    page-break-inside: avoid !important;
+  }
   ${withThemes(ArticleTextBlockContentTheme)}
 `;
 


### PR DESCRIPTION
Main issue was that in Firefox, the large images were being cut in the page break gutters. Second issue was that Flexbox was avoiding the code to avoid page breaks and content (esp. list and paragraphs) were being cut off in the page breaks. The fix was to set display to block in Print, thus allowing the avoidance code to be recognized. Also fixed minor issue where in the Article text blocks with float images, if not enough content was added, the image would hang outside of the wrapper. Protecting any future instances where this might become problematic.