### PR TITLE
feat: creating ProgressHeader partial to be used in editorial table components

### DIFF
--- a/v2/src/components/blocks/editorialTables/partials/ProgressHeader/ProgressHeader.tsx
+++ b/v2/src/components/blocks/editorialTables/partials/ProgressHeader/ProgressHeader.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import CircularButton from '../../../../partials/CircularButton/CircularButton';
+import styles from './progressHeader.module.scss';
+
+type ProgressHeaderProps = {
+  currentPage: number;
+  maxPage: number;
+  decrementPage: () => void;
+  incrementPage: () => void;
+};
+
+// TODO (A11Y): add aria labels for pages and buttons
+const ProgressHeader = ({ currentPage, maxPage, decrementPage, incrementPage }: ProgressHeaderProps) => {
+  return (
+    <div className={styles.wrapper}>
+      <p className={styles.pageIndicator}>
+        {currentPage + 1} of {maxPage}
+      </p>
+      <div>
+        <CircularButton onClick={decrementPage} iconType="leftArrow" />
+        <CircularButton onClick={incrementPage} iconType="rightArrow" />
+      </div>
+    </div>
+  );
+};
+
+export default ProgressHeader;

--- a/v2/src/components/blocks/editorialTables/partials/ProgressHeader/progressHeader.module.scss
+++ b/v2/src/components/blocks/editorialTables/partials/ProgressHeader/progressHeader.module.scss
@@ -1,0 +1,15 @@
+@import "../../../../../styles/main.scss";
+
+.wrapper {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 16px;
+  max-width: 848px;
+  width: 100%;
+}
+
+.pageIndicator {
+  color: $cBFont;
+  font: 1rem/1 $secondaryFont;
+}


### PR DESCRIPTION
Creating ProgressHeader component to be used in editorial table components. ProgressHeader indicates the current page a user is on and the max page number. It also renders two buttons meant to decrement and increment the current page number. Increment and decrement functionality is provided by parent component.