### PR TITLE
feat: ✨ add support for detailed comparison column headers to editorial tables

### DIFF
--- a/v2/src/components/blocks/editorialTables/EditorialTable/EditorialTable.stories.tsx
+++ b/v2/src/components/blocks/editorialTables/EditorialTable/EditorialTable.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import EditorialTable from './EditorialTable';
 
 export default {
-  title: 'Components/Blocks/Editorial Tables/EditorialTable',
+  title: 'Components/Blocks/EditorialTable',
   component: EditorialTable,
 } as ComponentMeta<typeof EditorialTable>;
 
@@ -20,28 +20,68 @@ ComparisonTablePaginated.args = {
         cells: [
           {
             id: 'row-one-cell-one',
-            content: 'Row Heading 1',
+            content: 'The Soda Maker',
             type: 'rowHeader',
           },
           {
             id: 'row-one-cell-two',
-            content: 'Column Heading 1',
-            type: 'header',
+            content: {
+              affiliate: {
+                text: 'Buy On Amazon',
+                url: 'https://www.amazon.com/dp/B097TD8V5P/?tag=atkequipchart-20',
+              },
+              image: {
+                cloudinaryUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_270/SIL_SodaStream_Terra_dbrqwh',
+              },
+              stickerText: 'Best For Most People',
+              title: 'SodaStream Terra',
+            },
+            type: 'colHeaderDetailed',
           },
           {
             id: 'row-one-cell-three',
-            content: 'Column Heading 2',
-            type: 'header',
+            content: {
+              affiliate: {
+                text: 'Buy On Williams Sonoma',
+                url: 'https://www.americastestkitchen.com',
+              },
+              image: {
+                cloudinaryUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_270/v1/ATK%20Reviews/2021/6_CIND_Soda%20Makers/SIL_SodaStream_AquaFizz_1876',
+              },
+              stickerText: 'Best With Glass',
+              title: 'SodaStream AquaFizz',
+            },
+            type: 'colHeaderDetailed',
           },
           {
             id: 'row-one-cell-four',
-            content: 'Column Heading 3',
-            type: 'header',
+            content: {
+              affiliate: {
+                text: 'Buy On Amazon',
+                url: '',
+              },
+              image: {
+                cloudinaryUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_270/v1/ATK%20Reviews/2021/6_CIND_Soda%20Makers/SIL_SodaStream_OneTouch-Electric_1842',
+              },
+              stickerText: 'Easiest To Use',
+              title: 'SodaStream OneTouch',
+            },
+            type: 'colHeaderDetailed',
           },
           {
             id: 'row-one-cell-five',
-            content: 'Column Heading 4',
-            type: 'header',
+            content: {
+              affiliate: {
+                text: 'Buy On Amazon',
+                url: '',
+              },
+              image: {
+                cloudinaryUrl: 'https://res.cloudinary.com/hksqkdlah/image/upload/c_fill,dpr_2.0,f_auto,fl_lossy.progressive.strip_profile,g_faces:auto,q_auto:low,w_270/v1/ATK%20Reviews/2021/6_CIND_Soda%20Makers/SIL_Aarke_Carbonator-III_1743',
+              },
+              stickerText: 'Most Stylish',
+              title: 'Column Heading 4',
+            },
+            type: 'colHeaderDetailed',
           },
         ],
         id: 'row-one',
@@ -50,27 +90,27 @@ ComparisonTablePaginated.args = {
         cells: [
           {
             id: 'row-two-cell-one',
-            content: 'Row Heading 2',
+            content: 'Carbonation Source',
             type: 'rowHeader',
           },
           {
             id: 'row-two-cell-two',
-            content: '<p>Text Cell 1</p>',
+            content: '<p>60-liter “quick connect” CO2 canisters</p>',
             type: 'text',
           },
           {
             id: 'row-two-cell-three',
-            content: '<p>Text Cell 2</p>',
+            content: '<p>60-liter CO2 canisters</p>',
             type: 'text',
           },
           {
             id: 'row-two-cell-four',
-            content: '<p>Text Cell 3</p>',
+            content: '<p>60-liter CO2 canisters</p>',
             type: 'text',
           },
           {
             id: 'row-two-cell-five',
-            content: '<p>Text Cell 4</p>',
+            content: '<p>60-liter CO2 canisters</p>',
             type: 'text',
           },
         ],
@@ -80,61 +120,120 @@ ComparisonTablePaginated.args = {
         cells: [
           {
             id: 'row-three-cell-one',
-            content: 'Row Heading 3',
+            content: 'Type of Water Bottle',
             type: 'rowHeader',
           },
           {
             id: 'row-three-cell-two',
-            content: 'yes',
-            type: 'icon',
+            content: '<p>Plastic (dishwasher-safe)</p>',
+            type: 'text',
           },
           {
             id: 'row-three-cell-three',
-            content: 'no',
-            type: 'icon',
+            content: '<p>Glass (dishwasher-safe)</p>',
+            type: 'text',
           },
           {
             id: 'row-three-cell-four',
-            content: 'yes',
-            type: 'icon',
+            content: '<p>Plastic (must be hand-washed)</p>',
+            type: 'text',
           },
           {
             id: 'row-three-cell-five',
-            content: 'no',
-            type: 'icon',
+            content: '<p>Plastic (must be hand-washed)</p>',
+            type: 'text',
           },
         ],
         id: 'row-three',
-      },
-      {
+      },      {
         cells: [
           {
             id: 'row-four-cell-one',
-            content: 'Row Header 4',
+            content: 'How It Works',
             type: 'rowHeader',
           },
           {
             id: 'row-four-cell-two',
-            content: 'Test',
+            content: '<p>Manually, by repeatedly pressing a button</p>',
             type: 'text',
           },
           {
             id: 'row-four-cell-three',
-            content: '',
-            type: 'empty',
+            content: '<p>Manually, by repeatedly pressing a button</p>',
+            type: 'text',
           },
           {
             id: 'row-four-cell-four',
-            content: '',
-            type: 'empty',
+            content: '<p>Automatically, by pressing a button that corresponds to a preprogrammed carbonation (low, medium, high)</p>',
+            type: 'text',
           },
           {
             id: 'row-four-cell-five',
-            content: '',
-            type: 'empty',
+            content: '<p>Manually, by repeatedly pressing a button</p>',
+            type: 'text',
           },
         ],
         id: 'row-four',
+      },
+      {
+        cells: [
+          {
+            id: 'row-five-cell-one',
+            content: 'Carbonate Liquids Other Than Water',
+            type: 'rowHeader',
+          },
+          {
+            id: 'row-five-cell-two',
+            content: 'no',
+            type: 'icon',
+          },
+          {
+            id: 'row-five-cell-three',
+            content: 'no',
+            type: 'icon',
+          },
+          {
+            id: 'row-five-cell-four',
+            content: 'no',
+            type: 'icon',
+          },
+          {
+            id: 'row-five-cell-five',
+            content: 'no',
+            type: 'icon',
+          },
+        ],
+        id: 'row-five',
+      },
+      {
+        cells: [
+          {
+            id: 'row-six-cell-one',
+            content: 'Requies Electricity',
+            type: 'rowHeader',
+          },
+          {
+            id: 'row-six-cell-two',
+            content: 'no',
+            type: 'icon',
+          },
+          {
+            id: 'row-six-cell-three',
+            content: 'no',
+            type: 'icon',
+          },
+          {
+            id: 'row-six-cell-four',
+            content: 'yes',
+            type: 'icon',
+          },
+          {
+            id: 'row-six-cell-five',
+            content: 'no',
+            type: 'icon',
+          },
+        ],
+        id: 'row-six',
       },
     ],
     type: 'comparison',
@@ -157,12 +256,12 @@ ComparisonTableNoPagination.args = {
           {
             id: 'row-one-cell-two',
             content: 'Column Heading 1',
-            type: 'header',
+            type: 'colHeader',
           },
           {
             id: 'row-one-cell-three',
             content: 'Column Heading 2',
-            type: 'header',
+            type: 'colHeader',
           },
         ],
         id: 'row-one',
@@ -243,22 +342,22 @@ InformationalTablePaginated.args = {
           {
             id: 'y5z24',
             content: 'Yes',
-            type: 'header',
+            type: 'colHeader',
           },
           {
             id: 'tof2t',
             content: 'No',
-            type: 'header',
+            type: 'colHeader',
           },
           {
             id: 'r4fot',
             content: 'Moderate',
-            type: 'header',
+            type: 'colHeader',
           },
           {
             id: 'hlr6f',
             content: 'Maybe',
-            type: 'header',
+            type: 'colHeader',
           },
         ],
         id: '0mx0g',
@@ -354,17 +453,17 @@ InformationalTableNoPagination.args = {
           {
             id: 'y5z24',
             content: 'Yes',
-            type: 'header',
+            type: 'colHeader',
           },
           {
             id: 'tof2t',
             content: 'No',
-            type: 'header',
+            type: 'colHeader',
           },
           {
             id: 'r4fot',
             content: 'Moderate',
-            type: 'header',
+            type: 'colHeader',
           },
         ],
         id: '0mx0g',

--- a/v2/src/components/blocks/editorialTables/partials/ProgressHeader/ProgressHeader.tsx
+++ b/v2/src/components/blocks/editorialTables/partials/ProgressHeader/ProgressHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cx from 'classnames';
 
 import CircularButton from '../../../../partials/CircularButton/CircularButton';
 import styles from './progressHeader.module.scss';
@@ -12,8 +13,13 @@ type ProgressHeaderProps = {
 
 // TODO (A11Y): add aria labels for pages and buttons
 const ProgressHeader = ({ currentPage, maxPage, decrementPage, incrementPage }: ProgressHeaderProps) => {
+  const classNames = cx(
+    styles.wrapper,
+    { [styles.hideDesktop]: maxPage <= 3 },
+  );
+
   return (
-    <div className={`${maxPage <= 3 && styles.hideDesktop} ${styles.wrapper}`}>
+    <div className={classNames}>
       <p className={styles.pageIndicator}>
         {currentPage + 1} of {maxPage}
       </p>

--- a/v2/src/components/blocks/editorialTables/partials/TableCard/TableCard.tsx
+++ b/v2/src/components/blocks/editorialTables/partials/TableCard/TableCard.tsx
@@ -41,9 +41,9 @@ const TableCard = ({ currentPage, table }: TableCardProps) => {
                         <TableCell
                           {...cell}
                           key={cell.id}
-                          rowHeaderContent={rowHeader?.content}
+                          rowHeaderContent={typeof rowHeader?.content === 'string' ? rowHeader.content : undefined}
                           indexInRow={index}
-                      tableType={type}
+                          tableType={type}
                         />
                       )
                   })}

--- a/v2/src/components/blocks/editorialTables/partials/TableCell/TableCell.tsx
+++ b/v2/src/components/blocks/editorialTables/partials/TableCell/TableCell.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 
 import CircularIcon from '../../../../partials/CircularIcon/CircularIcon';
 import styles from './tableCell.module.scss';
+import Sticker from '../../../../partials/Sticker/Sticker';
 
 type TableCellProps = EditorialTableCell & {
   indexInRow: number;
@@ -22,19 +23,45 @@ const TableCell = ({ content, isInFirstRow, rowHeaderContent, tableType, type, i
     { [styles.oobTablet]: indexInRow > 1 },
     { [styles.oobDesktop]: indexInRow > 2 }
   );
+
+  const cellContentClassNames = cx(
+    styles.content,
+    styles.divider,
+  );
   
   const rowHeaderEl = rowHeaderContent ? <p className={styles.inlineRowHeading}>{rowHeaderContent}</p> : null;
-  const dividerEl = <hr aria-hidden="true" className={styles.divider} />;
 
   switch(type) {
     case 'rowHeader':
+      const rowHeaderContentClassNames = cx(
+        styles.content,
+        { [styles.divider]: !isInFirstRow },
+      );
       return (
-        <th className={cellClassNames} >
-          {!isInFirstRow ? dividerEl : null}
-          {content}
+        <th className={cellClassNames}>
+          <div className={rowHeaderContentClassNames}>
+            {content}
+          </div>
         </th>
       );
-    case 'header':
+    case 'colHeaderDetailed':
+      const { affiliate, image, stickerText, title} = content;
+      return (
+        <th className={cellClassNames}>
+          {rowHeaderEl}
+          {image ? <img alt={image.altText ?? ''} className={styles.chdImage} src={image.cloudinaryUrl} /> : null}
+          {stickerText ? <Sticker text={stickerText} type="editorial" /> : null}
+          <span className={styles.chdTitle}>{title}</span>
+          {
+            affiliate ? (
+              <a className={styles.affiliate} href={affiliate.url}>
+                {affiliate.text} <span className={styles.affiliateArrow}>▸</span>
+              </a> 
+            ) : null
+          }
+        </th>
+      );
+    case 'colHeader':
       return (
         <th className={cellClassNames}>
           {rowHeaderEl}
@@ -47,22 +74,24 @@ const TableCell = ({ content, isInFirstRow, rowHeaderContent, tableType, type, i
       // when icon cell type is selected
       return (
         <td className={cellClassNames}>
-          {dividerEl}
-          {rowHeaderEl}
-          <div className={styles.iconWrapper}>
-            <div className={`${styles[content]} ${styles.iconSvg}`}>
-              <CircularIcon type={content === 'yes' ? 'checkmark' : 'close'} />
+          <div className={cellContentClassNames}>
+            {rowHeaderEl}
+            <div className={styles.iconWrapper}>
+              <div className={`${styles[content]} ${styles.iconSvg}`}>
+                <CircularIcon type={content === 'yes' ? 'checkmark' : 'close'} />
+              </div>
+              {content}
             </div>
-            {content}
           </div>
         </td>
       );
     case 'text':
       return (
         <td className={cellClassNames}>
-          {dividerEl}
-          {rowHeaderEl}
-          <span dangerouslySetInnerHTML={{ __html: content }} />
+          <div className={cellContentClassNames}>
+            {rowHeaderEl}
+            <span dangerouslySetInnerHTML={{ __html: content }} />
+          </div>
         </td>
       );
     default:

--- a/v2/src/components/blocks/editorialTables/partials/TableCell/tableCell.module.scss
+++ b/v2/src/components/blocks/editorialTables/partials/TableCell/tableCell.module.scss
@@ -1,5 +1,6 @@
 @import "../../../../../styles/main.scss";
 
+// **** General Cell Styles ****
 .cell {
   display: flex;
   flex-direction: column;
@@ -9,20 +10,28 @@
 }
 
 .informationalCell {
+  min-width: 272px;
   max-width: 272px;
 }
 
 .comparisonCell {
+  min-width: 200px;
   max-width: 200px;
 }
 
-.divider {
-  background-color: $cNGray;
-  margin-bottom: 20px;
-  height: 1px;
-  width: 100%;
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+  padding-top: 20px;
 }
 
+.divider {
+  border-top: solid 1px $cNGray;
+}
+
+// **** Out of Bounds Styles ****
 // TODO: add breakpoint tokens
 .oobMobile {
   @media (max-width: 768px) {
@@ -42,11 +51,42 @@
   }
 }
 
-.header {
+// **** Column Header Styles ****
+.colHeader {
   font: 1.125rem/1 $secondaryFont;
   padding-top: 20px;
 }
 
+.colHeaderDetailed {
+  justify-content: flex-start;
+  padding-top: 20px;
+
+  :global(.sticker) {
+    margin-top: 14px;
+  }
+}
+
+.chdImage {
+  max-height: 100px;
+  max-width: 100px;
+}
+
+.chdTitle {
+  font: 1rem/1.25 $secondaryFont;
+  margin-top: 14px
+}
+
+.affiliate {
+  font: 1rem/1.38 $primaryFont;
+  margin-top: 6px;
+  width: 97%;
+}
+
+.affiliateArrow {
+  color: $cAAction;
+}
+
+// **** Row Header Styles ****
 .rowHeader {
   background-color: transparent;
   font: 1.125rem/1 $secondaryFont;
@@ -62,11 +102,6 @@
   padding-top: 20px;
 }
 
-.icon,
-.text {
-  font: 1rem/1.63 $primaryFont;
-}
-
 .inlineRowHeading {
   background-color: #E9F0F0;
   font: 1rem/1 $secondaryFont;
@@ -76,6 +111,16 @@
   @media (min-width: 769px) {
     display: none;
   }
+}
+
+// **** Icon and Text Cell Styles ****
+.icon,
+.text {
+  font: 1rem/1.63 $primaryFont;
+}
+
+.icon {
+  text-transform: capitalize;
 }
 
 .no {

--- a/v2/src/components/blocks/editorialTables/types.ts
+++ b/v2/src/components/blocks/editorialTables/types.ts
@@ -2,10 +2,24 @@
 type EditorialTableHeaderCell = {
   content: string;
   id: string;
-  type: 'header';
+  type: 'colHeader';
 };
 
-type EditorialTableRowHeaderCell = {
+type EditorialTableDetailedHeaderCell = {
+  content: {
+    affiliate?: { text: string; url: string; };
+    image?: {
+      altText?: string;
+      cloudinaryUrl: string;
+    },
+    stickerText?: string;
+    title: string;
+  }
+  id: string;
+  type: 'colHeaderDetailed';
+};
+
+export type EditorialTableRowHeaderCell = {
   content: string;
   id: string;
   type: 'rowHeader';
@@ -31,6 +45,7 @@ type EditorialTableEmptyCell = {
 
 export type EditorialTableCell = EditorialTableEmptyCell
   | EditorialTableHeaderCell
+  | EditorialTableDetailedHeaderCell
   | EditorialTableRowHeaderCell
   | EditorialTableIconCell
   | EditorialTableTextCell;

--- a/v2/src/components/partials/Sticker/Sticker.tsx
+++ b/v2/src/components/partials/Sticker/Sticker.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cx from 'classnames';
 
 import styles from './sticker.module.scss';
 
@@ -7,10 +8,18 @@ export type StickerProps = {
   type: 'editorial' | 'priority';
 };
 
-const Sticker = ({ text, type }: StickerProps) => (
-  <div className={`${styles.wrapper} ${styles[type]}`}>
-    {text}
-  </div>
-);
+const Sticker = ({ text, type }: StickerProps) => {
+  const classNames = cx(
+    styles.wrapper,
+    styles[type],
+    'sticker',
+  );
+
+  return (
+    <div className={classNames}>
+      {text}
+    </div>
+  );
+};
 
 export default Sticker;

--- a/v2/src/components/partials/Sticker/sticker.module.scss
+++ b/v2/src/components/partials/Sticker/sticker.module.scss
@@ -16,4 +16,5 @@
   letter-spacing: 1.6px;
   padding: 4px 8px;
   text-transform: uppercase;
+  width: fit-content;
 }


### PR DESCRIPTION
* Added type and component support for detailed Comparison Table column headers: `colHeaderDetailed`
* Added more detailed story example for a Comparison Table
* Renamed `TableCell` type from `header` to `colHeader`
* Updated divider styles in `TableCell` to use border styles