### PR TITLE
feat: ✨ adding temporary brand styles to EditorialTable component

### DIFF
--- a/v2/src/components/blocks/editorialTables/EditorialTable/EditorialTable.stories.tsx
+++ b/v2/src/components/blocks/editorialTables/EditorialTable/EditorialTable.stories.tsx
@@ -238,6 +238,7 @@ ComparisonTablePaginated.args = {
     ],
     type: 'comparison',
   },
+  brandKey: 'atk',
 };
 
 export const ComparisonTableNoPagination = Template.bind({});
@@ -329,6 +330,7 @@ ComparisonTableNoPagination.args = {
     ],
     type: 'comparison',
   },
+  brandKey: 'atk',
 };
 
 export const InformationalTablePaginated = Template.bind({});
@@ -440,6 +442,7 @@ InformationalTablePaginated.args = {
     ],
     type: 'informational',
   },
+  brandKey: 'atk',
 };
 
 export const InformationalTableNoPagination = Template.bind({});
@@ -511,4 +514,5 @@ InformationalTableNoPagination.args = {
     ],
     type: 'informational',
   },
+  brandKey: 'atk',
 };

--- a/v2/src/components/blocks/editorialTables/EditorialTable/EditorialTable.tsx
+++ b/v2/src/components/blocks/editorialTables/EditorialTable/EditorialTable.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import cx from 'classnames';
 
 import ProgressHeader from '../partials/ProgressHeader/ProgressHeader';
 import TableCard from '../partials/TableCard/TableCard';
@@ -7,11 +8,18 @@ import { EditorialTableType } from '../types';
 
 type EditorialTableProps = {
   description?: string;
+  brandKey: 'atk' | 'cco' | 'cio';
   heading: string;
   table: EditorialTableType;
 };
 
-const EditorialTable = ({ description, heading, table }: EditorialTableProps) => {
+const EditorialTable = ({ description, heading, table, brandKey }: EditorialTableProps) => {
+  const wrapperClassNames = cx(
+    styles.wrapper,
+    `${table.type}`,
+    { [styles[brandKey]]: brandKey !== 'atk'},
+  );
+
   const { rows, type } = table;
   const firstRowCells = rows[0].cells;
   // Subtract a page for comparison table because row header column
@@ -29,7 +37,7 @@ const EditorialTable = ({ description, heading, table }: EditorialTableProps) =>
   }, []);
 
   return (
-    <div className={styles.wrapper}>
+    <div className={wrapperClassNames}>
       <div>
         <h2 className={styles.heading}>{heading}</h2>
         {description && <p className={styles.description}>{description}</p>}

--- a/v2/src/components/blocks/editorialTables/EditorialTable/editorialTable.module.scss
+++ b/v2/src/components/blocks/editorialTables/EditorialTable/editorialTable.module.scss
@@ -12,3 +12,68 @@
   font: $fBodyMd;
   margin-top: 16px;
 }
+
+
+// **** Temprorary Brand Style Overrides ****
+.cco {
+  color: $ccoCBFont !important;
+
+  :global(.progress-header):global(__page-indicator) {
+    color: $ccoCBFont !important;
+  }
+  
+  :global(.circular-button) {
+    :global(.circular-icon) {
+      background-color: $ccoCBPrimary !important;
+
+      &:hover {
+        background-color: $ccoCBPrimaryHover !important;
+      }
+    }
+  }
+
+  :global(.editorial-table-header-cell) {
+    border: solid 4px $cNGrayLight;
+    border-bottom: none;
+  }
+
+  &:global(.comparison) {
+    :global(.editorial-table-header-cell) {
+      &:first-child {
+        border: none;
+      }
+    }
+  }
+  
+  :global(.editorial-table-data-cell) {
+    border: solid 4px $cNGrayLight;
+    border-top: none;
+    border-bottom: none;
+  }
+
+  :global(.editorial-table-row) {
+    &:last-child {
+      :global(.editorial-table-data-cell) {
+        border-bottom: solid 4px $cNGrayLight;
+      }
+    }
+  }
+}
+
+.cio {
+  color: $cioCBFont !important;
+
+  :global(.progress-header):global(__page-indicator) {
+    color: $cioCBFont !important;
+  }
+  
+  :global(.circular-button) {
+    :global(.circular-icon) {
+      background-color: $cioCBPrimary !important;
+
+      &:hover {
+        background-color: $cioCBPrimaryHover !important;
+      }
+    }
+  }
+}

--- a/v2/src/components/blocks/editorialTables/partials/ProgressHeader/ProgressHeader.tsx
+++ b/v2/src/components/blocks/editorialTables/partials/ProgressHeader/ProgressHeader.tsx
@@ -13,14 +13,20 @@ type ProgressHeaderProps = {
 
 // TODO (A11Y): add aria labels for pages and buttons
 const ProgressHeader = ({ currentPage, maxPage, decrementPage, incrementPage }: ProgressHeaderProps) => {
-  const classNames = cx(
+  const wrapperClassNames = cx(
+    'progress-header',
     styles.wrapper,
     { [styles.hideDesktop]: maxPage <= 3 },
   );
 
+  const pageIndicatorClassNames = cx(
+    'progress-header__page-indicator',
+    styles.pageIndicator,
+  );
+
   return (
-    <div className={classNames}>
-      <p className={styles.pageIndicator}>
+    <div className={wrapperClassNames}>
+      <p className={pageIndicatorClassNames}>
         {currentPage + 1} of {maxPage}
       </p>
       <div>

--- a/v2/src/components/blocks/editorialTables/partials/TableCard/TableCard.tsx
+++ b/v2/src/components/blocks/editorialTables/partials/TableCard/TableCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cx from 'classnames';
 
 import TableCell from '../TableCell/TableCell';
 import styles from './tableCard.module.scss';
@@ -22,8 +23,12 @@ const TableCard = ({ currentPage, table }: TableCardProps) => {
               rowHeader = row.cells[0];
               pageSlice = currentPage + 1;
             }
+            const rowClassNames = cx(
+              'editorial-table-row',
+              styles.row,
+            );
             return (
-              <tr className={styles.row} key={row.id}>
+              <tr className={rowClassNames} key={row.id}>
                 {
                   rowHeader ? (
                     <TableCell

--- a/v2/src/components/blocks/editorialTables/partials/TableCell/TableCell.tsx
+++ b/v2/src/components/blocks/editorialTables/partials/TableCell/TableCell.tsx
@@ -15,6 +15,7 @@ type TableCellProps = EditorialTableCell & {
 
 const TableCell = ({ content, isInFirstRow, rowHeaderContent, tableType, type, indexInRow }: TableCellProps) => {
   const cellClassNames = cx(
+    type.includes('Header') ? 'editorial-table-header-cell' : 'editorial-table-data-cell',
     styles.cell,
     styles[type],
     styles[`${tableType}Cell`],

--- a/v2/src/components/partials/CircularButton/CircularButton.tsx
+++ b/v2/src/components/partials/CircularButton/CircularButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cx from 'classnames';
 
 import CircularIcon from '../CircularIcon/CircularIcon';
 import { IconType } from '../../tokens/icons/svgs/useIconMap';
@@ -9,10 +10,17 @@ type CircularButtonProps = {
   onClick: () => void;
 };
 
-const CircularButton = ({ iconType, onClick }: CircularButtonProps) => (
-  <button className={styles.button} onClick={onClick}>
-    <CircularIcon type={iconType} />
-  </button>
-);
+const CircularButton = ({ iconType, onClick }: CircularButtonProps) => {
+  const classNames = cx(
+    'circular-button',
+    styles.button,
+  );
+
+  return (
+    <button className={classNames} onClick={onClick}>
+      <CircularIcon type={iconType} />
+    </button>
+  );
+};
 
 export default CircularButton;

--- a/v2/src/styles/colors/_cco_colors.scss
+++ b/v2/src/styles/colors/_cco_colors.scss
@@ -9,14 +9,14 @@ $cCornflower: #e6f1ff;
 $cAliceBlue: #f7faff;
 
 // Brand - $cB
-$cBPrimary: $cDenim;
-$cBPrimaryHover: $cArapawa;
-$cBFont: $cBlack;
-$cBFontHover: $cDenim;
-$cBLink: $cMalibu;
-$cBLinkHover: $cCornflower;
+$ccoCBPrimary: $cDenim;
+$ccoCBPrimaryHover: $cNBlack;
+$ccoCBFont: $cBlack;
+$ccoCBFontHover: $cDenim;
+$ccoCBLink: $cMalibu;
+$ccoCBLinkHover: $cCornflower;
 
 // Backgrounds - $cBG
-$cBGPage: $cNWhite;
-$cBGCallout: $cAliceBlue;
+$ccoCBGPage: $cNWhite;
+$ccoCBGCallout: $cAliceBlue;
 

--- a/v2/src/styles/colors/_cio_colors.scss
+++ b/v2/src/styles/colors/_cio_colors.scss
@@ -9,15 +9,13 @@ $cLinen: #fcf9f3;
 $cIvory: #fffdeb;
 
 // Brand - $cB
-$cBPrimary: $cCork;
-$cBPrimaryHover: $cSquirrel;
-$cBSecondary: $cSquirrel;
-$cBSecondaryHover: $cCork;
-$cBFont: $cCork;
-$cBFontHover: $cSquirrel;
-$cBLink: $cDijon;
-$cBLinkHover: $cSand;
+$cioCBPrimary: $cSquirrel;
+$cioCBPrimaryHover: $cCork;
+$cioCBFont: $cCork;
+$cioCBFontHover: $cSquirrel;
+$cioCBLink: $cDijon;
+$cioCBLinkHover: $cSand;
 
 // Backgrounds - $cBG
-$cBGPage: $cLinen;
-$cBGCallout: $cIvory;
+$cioCBGPage: $cLinen;
+$cioCBGCallout: $cIvory;

--- a/v2/src/styles/main.scss
+++ b/v2/src/styles/main.scss
@@ -1,3 +1,5 @@
 @import "./_reset.scss";
 @import "./colors/_atk_colors.scss";
+@import "./colors/_cco_colors.scss";
+@import "./colors/_cio_colors.scss";
 @import "./typography/_fonts.scss";


### PR DESCRIPTION
For release editorial tables need to support different styles across our 3 brands. These brand specific styles will go away as we move forward with more brand consolidation starting with the homepage redesign. Since these styles are temporary, a robust theming solution is not needed. I updated the `EditorialTable` component to take a `domainSiteKey` prop. If that prop is present and is not `atk`, a site key module class will be applied to the table that will override button and text colors.