### PR TITLE
feat: ✨ creating EditorialText component to be used to render WSYIWYG content from barista

### DIFF
--- a/v2/.storybook/preview-head.html
+++ b/v2/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<link href="https://fonts.googleapis.com/css?family=Merriweather:400,400i,700&display=swap" rel="stylesheet">

--- a/v2/src/components/partials/EditorialText/EditorialText.stories.tsx
+++ b/v2/src/components/partials/EditorialText/EditorialText.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import EditorialText from './EditorialText';
+
+export default {
+  title: 'Components/Partials/EditorialText',
+  component: EditorialText,
+} as ComponentMeta<typeof EditorialText>;
+
+const Template: ComponentStory<typeof EditorialText> = args => <EditorialText {...args} />;
+
+export const SampleContent = Template.bind({});
+SampleContent.args = {
+  content: '<p>This component is meant to be used when we need to render WSYIWYG text fields.</p><p>Currently it can style <a href="https://www.americastestkitchen.com">underlined links</a>, <em>italicized text</em>, and <strong>bolded text</strong>.</p>',
+  fontStyle: 'primary',
+};

--- a/v2/src/components/partials/EditorialText/EditorialText.tsx
+++ b/v2/src/components/partials/EditorialText/EditorialText.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import cx from 'classnames';
+
+import styles from './editorialText.module.scss';
+
+type EditorialTextProps = {
+  content: string;
+  fontStyle?: 'accent' | 'primary';
+};
+
+const EditorialText = ({ content, fontStyle = 'primary' }: EditorialTextProps) => {
+  const classNames = cx(
+    'editorial-text',
+    styles.wrapper,
+    styles[fontStyle],
+  );
+
+  return (
+    <div
+      className={classNames}
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  );
+};
+
+export default EditorialText;

--- a/v2/src/components/partials/EditorialText/editorialText.module.scss
+++ b/v2/src/components/partials/EditorialText/editorialText.module.scss
@@ -1,0 +1,25 @@
+@import "../../../styles/main.scss";
+
+.wrapper {
+  @include underlined-link;
+
+  em {
+    font-style: italic;
+  }
+}
+
+.primary {
+  font-family: $primaryFont;
+
+  strong {
+    font-family: $secondaryFont;
+  }
+}
+
+.accent {
+  font-family: $accentFont;
+
+  strong {
+    font-weight: bold;
+  }
+}

--- a/v2/src/styles/main.scss
+++ b/v2/src/styles/main.scss
@@ -1,3 +1,4 @@
 @import "./_reset.scss";
 @import "./colors/_atk_colors.scss";
 @import "./typography/_fonts.scss";
+@import "./mixins.scss";

--- a/v2/src/styles/mixins.scss
+++ b/v2/src/styles/mixins.scss
@@ -1,0 +1,12 @@
+@mixin underlined-link {
+  a {
+    background-image: linear-gradient(transparent 91%,  $cBLink 91%);
+    transition: background-color 0.2s ease-in-out 0s;
+
+    @media(hover: hover) {
+      &:hover {
+        background-color: $cBLinkHover;
+      }
+    }
+  }
+}

--- a/v2/src/styles/typography/_fonts.scss
+++ b/v2/src/styles/typography/_fonts.scss
@@ -12,6 +12,7 @@ $baseFontSize: 16px;
 $baseLineHeight: 1.5;
 $primaryFont: $proximaNova;
 $secondaryFont: $proximaNovaBold;
+$accentFont: $merriweather;
 
 // - $f
 $fBodySm: 0.875rem/1rem $primaryFont; // 14px/16px


### PR DESCRIPTION
mise v2.0 update

* created `EditorialText` component that should be used to render WYSIWYG content from barista
* Component currently supports styling for links, italicized, and bolded text (ordered and unordered list support should be added later)
* Supports rendering with primary font (currently proximaNova, but may change) and accent font (currently merriweather)
* Font sizes and line heights should be set by the parent component that renders EditorialText as those values vary for WYSIWYG content across pages