### PR TITLE
refactor: :recycle: updating temporary brand theming solution in v2

### DIFF
--- a/v2/.storybook/preview.js
+++ b/v2/.storybook/preview.js
@@ -7,3 +7,26 @@ export const parameters = {
     },
   },
 }
+
+// TODO(Brand Theme): remove after brand consolidation
+export const globalTypes = {
+  theme: {
+    name: 'Brand Theme',
+    description: 'Applies brand theme class to stories for components that need it.',
+    defaultValue: 'atk-theme',
+    toolbar: {
+      icon: 'heart',
+      items: ['atk-theme', 'cco-theme', 'cio-theme'],
+      dynamicTitle: true,
+    },
+  },
+};
+
+// TODO(Brand Theme): remove after brand consolidation
+const useBrandTheme = (Story, { globals }) => (
+  <div className={globals.theme}>
+    <Story />
+  </div>
+);
+
+export const decorators = [useBrandTheme];

--- a/v2/src/components/partials/EditorialText/editorialText.module.scss
+++ b/v2/src/components/partials/EditorialText/editorialText.module.scss
@@ -3,8 +3,20 @@
 .wrapper {
   @include underlined-link;
 
+  color: $cBFont;
+
   em {
     font-style: italic;
+  }
+
+  // TODO(Brand Theme): remove after brand consolidation
+  :global(.cco-theme) & {
+    color: $ccoCBFont;
+  }
+
+  // TODO(Brand Theme): remove after brand consolidation
+  :global(.cio-theme) & {
+    color: $cioCBFont;
   }
 }
 

--- a/v2/src/styles/colors/_cco_colors.scss
+++ b/v2/src/styles/colors/_cco_colors.scss
@@ -9,14 +9,14 @@ $cCornflower: #e6f1ff;
 $cAliceBlue: #f7faff;
 
 // Brand - $cB
-$cBPrimary: $cDenim;
-$cBPrimaryHover: $cArapawa;
-$cBFont: $cBlack;
-$cBFontHover: $cDenim;
-$cBLink: $cMalibu;
-$cBLinkHover: $cCornflower;
+$ccoCBPrimary: $cDenim;
+$ccoCBPrimaryHover: $cArapawa;
+$ccoCBFont: $cBlack;
+$ccoCBFontHover: $cDenim;
+$ccoCBLink: $cMalibu;
+$ccoCBLinkHover: $cCornflower;
 
 // Backgrounds - $cBG
-$cBGPage: $cNWhite;
-$cBGCallout: $cAliceBlue;
+$ccoCBGPage: $cNWhite;
+$ccoCBGCallout: $cAliceBlue;
 

--- a/v2/src/styles/colors/_cio_colors.scss
+++ b/v2/src/styles/colors/_cio_colors.scss
@@ -9,15 +9,15 @@ $cLinen: #fcf9f3;
 $cIvory: #fffdeb;
 
 // Brand - $cB
-$cBPrimary: $cCork;
-$cBPrimaryHover: $cSquirrel;
-$cBSecondary: $cSquirrel;
-$cBSecondaryHover: $cCork;
-$cBFont: $cCork;
-$cBFontHover: $cSquirrel;
-$cBLink: $cDijon;
-$cBLinkHover: $cSand;
+$cioCBPrimary: $cCork;
+$cioCBPrimaryHover: $cSquirrel;
+$cioCBSecondary: $cSquirrel;
+$cioCBSecondaryHover: $cCork;
+$cioCBFont: $cCork;
+$cioCBFontHover: $cSquirrel;
+$cioCBLink: $cDijon;
+$cioCBLinkHover: $cSand;
 
 // Backgrounds - $cBG
-$cBGPage: $cLinen;
-$cBGCallout: $cIvory;
+$cioCBGPage: $cLinen;
+$cioCBGCallout: $cIvory;

--- a/v2/src/styles/main.scss
+++ b/v2/src/styles/main.scss
@@ -1,4 +1,6 @@
 @import "./_reset.scss";
 @import "./colors/_atk_colors.scss";
+@import "./colors/_cco_colors.scss";
+@import "./colors/_cio_colors.scss";
 @import "./typography/_fonts.scss";
 @import "./mixins.scss";

--- a/v2/src/styles/mixins.scss
+++ b/v2/src/styles/mixins.scss
@@ -8,5 +8,27 @@
         background-color: $cBLinkHover;
       }
     }
+
+    // TODO(Brand Theme): remove after brand consolidation
+    :global(.cco-theme) & {
+      background-image: linear-gradient(transparent 91%,  $ccoCBLink 91%);
+
+      @media(hover: hover) {
+        &:hover {
+          background-color: $ccoCBLinkHover;
+        }
+      }
+    }
+
+    // TODO(Brand Theme): remove after brand consolidation
+    :global(.cio-theme) & {
+      background-image: linear-gradient(transparent 91%,  $cioCBLink 91%);
+
+      @media(hover: hover) {
+        &:hover {
+          background-color: $cioCBLinkHover;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
* created a storybook global and decorator that apply a theme class to stories based on our brands. the global config adds a toolbar to the top of each story that allows you to select a brand theme for the story. the default theme is atk
* components can detect if they're under a themed class with the scss selector `:global(.brandKey-theme) &` and then apply appropriate styles
* this is pattern will be used temporarily for tables and article recipe components and will be removed once brand style consolidation starts early next year