### PR TITLE
WEB-1282: Release

### DIFF
--- a/src/components/Cards/RelatedContentCard/AffiliateFakeButton.tsx
+++ b/src/components/Cards/RelatedContentCard/AffiliateFakeButton.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+import { color, font, fontSize, lineHeight, mixins, withThemes } from '../../../styles';
+import * as Icons from '../../DesignTokens/Icon';
+
+const AffiliateLinkWrapperTheme = {
+  default: css`
+    display: inline-block;
+    position: relative;
+    white-space: nowrap;
+
+    > img {
+      display: block;
+      margin: 0 auto;
+      width: 10rem;
+    }
+
+    @media print {
+      display: none;
+    }
+  `,
+};
+
+const AffiliateLinkWrapper = styled.div.attrs({
+  className: 'partner-link',
+})`${withThemes(AffiliateLinkWrapperTheme)}`;
+
+const AffiliateLinkTheme = {
+  default: css`
+    background-color: ${color.dirtyLinen};
+    border-radius: 3rem;
+    color: ${color.rust};
+    display: inline-block;
+    font: ${fontSize.md}/${lineHeight.md} ${font.pnb};
+    min-width: 16.2rem;
+    padding: 1rem 2rem;
+    position: relative;
+    text-align: center;
+    z-index: 1;
+    ${mixins.truncate(null)}
+    &:focus, &:active {
+      ${mixins.focusIndicator()};
+    }
+
+    @media(hover: hover) {
+      &:hover {
+        background-color: ${color.palePink};
+      }
+    }
+
+    svg {
+      display: inline-block;
+      fill: ${color.rust};
+      height: 0.9rem;
+      margin-left: 0.5rem;
+      position: relative;
+      top: 50%;
+      width: 0.9rem;
+    }
+  `,
+};
+
+const AffiliateLinkEl = styled.div.attrs({
+  className: 'partner-link__anchor',
+})`${withThemes(AffiliateLinkTheme)}`;
+
+type AffiliateFakeButtonProps = {
+    text: string;
+}
+
+const AffiliateFakeButton = ({
+  text,
+}: AffiliateFakeButtonProps) => (
+  <AffiliateLinkWrapper>
+    <AffiliateLinkEl>
+      {text}
+      <Icons.TriangleRight />
+    </AffiliateLinkEl>
+  </AffiliateLinkWrapper>
+);
+
+export default AffiliateFakeButton;

--- a/src/components/Cards/RelatedContentCard/RelatedContentCard.tsx
+++ b/src/components/Cards/RelatedContentCard/RelatedContentCard.tsx
@@ -4,7 +4,7 @@ import { font, color, withThemes, mixins } from '../../../styles';
 import { md, untilMd } from '../../../styles/breakpoints';
 import { cssThemedColor, cssThemedFontAccentColorAlt, cssThemedLink } from '../../../styles/mixins';
 import useMedia from '../../hooks/useMedia';
-import AffiliateLink from '../shared/AffiliateLink';
+import AffiliateFakeButton from './AffiliateFakeButton';
 
 const mobileCard = untilMd;
 const desktopCard = md;
@@ -104,7 +104,7 @@ const Body = styled.span`
     ${mixins.truncateLineClamp(3)}
 `;
 
-const LinkText = styled.a`
+const LinkText = styled.div`
   ${cssLinkTextFont}
 `;
 
@@ -203,7 +203,7 @@ export const WideCard = {
   Body,
   LinkWrapper,
   LinkText,
-  AffiliateLink,
+  AffiliateLink: AffiliateFakeButton,
 };
 
 export type RelatedContentCardProps = {
@@ -232,7 +232,6 @@ export type RelatedContentCardProps = {
 /** Preview helper, example implemenation, and validating exports */
 export default function RelatedContentCard({
   href,
-  buttonHref,
   src,
   headline,
   title,
@@ -253,9 +252,9 @@ export default function RelatedContentCard({
         <WideCard.Body dangerouslySetInnerHTML={{ __html: body }} />
         <WideCard.LinkWrapper>
           {!!link && !!withButton ? (
-            <WideCard.AffiliateLink text={link} url={buttonHref || href} />
+            <WideCard.AffiliateLink text={link} />
           ) : (
-            <WideCard.LinkText href={href}>{link}</WideCard.LinkText>
+            <WideCard.LinkText>{link}</WideCard.LinkText>
           )}
         </WideCard.LinkWrapper>
       </ThemeProvider>

--- a/src/styles/mixins.js
+++ b/src/styles/mixins.js
@@ -157,7 +157,7 @@ export default {
 
   /**
    * Truncates text with ellipsis
-   * @param  {Number} width optional - set the width of the element
+   * @param  {?Number} width optional - set the width of the element
    * @return {String}       CSS Text
    */
   truncate(width) {


### PR DESCRIPTION
[WEB-1282](https://bostoncommonpress.atlassian.net/browse/WEB-1282): Fake button for affiliates/text-link, (never different than card link, buttonHref unused)

We have overlapping anchor tags where the anchor link was never set up to be different than the card link. Make overlapping anchor a fake button for better accessibility navigation.