### PR TITLE
web-2464 Removing the Brand badge from all cards. 

### DIFF
--- a/src/components/Ads/ShowcaseAds/SingleProductShowcaseAd/index.js
+++ b/src/components/Ads/ShowcaseAds/SingleProductShowcaseAd/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 import Badge from '../../../Badge';
+import hasBrandBadge from '../../../Badge/utilities/hasBrandBadge';
 import { getImageUrl } from '../../../../lib/cloudinary';
 import {
   color,
@@ -175,57 +176,58 @@ const SingleProductShowcaseAd = ({
   siteKey,
   subtitle,
   title,
-}) => (
-  <Product>
-    <ProductPicture>
-      <source
-        media="(min-width: 1024px)"
-        srcSet={getImageUrl(
-          cloudinaryId,
-          'showcaseFreeTrialDesktop',
-        )}
-      />
-      <source
-        media="(min-width: 768px)"
-        srcSet={getImageUrl(
-          cloudinaryId,
-          'showcaseFreeTrialTablet',
-        )}
-      />
-      <img
-        alt={alt}
-        crossOrigin="anonymous"
-        decoding="async"
-        data-testid="product-img"
-        src={getImageUrl(
-          cloudinaryId,
-          'showcaseFreeTrialMobile',
-        )}
-      />
-    </ProductPicture>
-    <ProductInfo>
-      <ProductInfoInner>
-        <ProductTitle>
-          {title}
-        </ProductTitle>
-        <ProductSubtitle>
-          {subtitle}
-        </ProductSubtitle>
-        <ProductCta
-          href={ctaHref}
-          onClick={onClick}
-          target={ctaTarget}
-          title={cta}
-        >
-          {cta}
-        </ProductCta>
-      </ProductInfoInner>
-    </ProductInfo>
-    <Badge
-      type={siteKey}
-    />
-  </Product>
-);
+}) => {
+  const BrandBadge = hasBrandBadge(siteKey);
+  return (
+    <Product>
+      <ProductPicture>
+        <source
+          media="(min-width: 1024px)"
+          srcSet={getImageUrl(
+            cloudinaryId,
+            'showcaseFreeTrialDesktop',
+          )}
+        />
+        <source
+          media="(min-width: 768px)"
+          srcSet={getImageUrl(
+            cloudinaryId,
+            'showcaseFreeTrialTablet',
+          )}
+        />
+        <img
+          alt={alt}
+          crossOrigin="anonymous"
+          decoding="async"
+          data-testid="product-img"
+          src={getImageUrl(
+            cloudinaryId,
+            'showcaseFreeTrialMobile',
+          )}
+        />
+      </ProductPicture>
+      <ProductInfo>
+        <ProductInfoInner>
+          <ProductTitle>
+            {title}
+          </ProductTitle>
+          <ProductSubtitle>
+            {subtitle}
+          </ProductSubtitle>
+          <ProductCta
+            href={ctaHref}
+            onClick={onClick}
+            target={ctaTarget}
+            title={cta}
+          >
+            {cta}
+          </ProductCta>
+        </ProductInfoInner>
+      </ProductInfo>
+      {BrandBadge && (<Badge type={siteKey} />)}
+    </Product>
+  );
+};
 
 SingleProductShowcaseAd.propTypes = {
   alt: PropTypes.string,

--- a/src/components/Badge/__tests__/Badge.spec.js
+++ b/src/components/Badge/__tests__/Badge.spec.js
@@ -14,11 +14,6 @@ describe('Badge', () => {
     )
   );
 
-  it('renders an atk badge', () => {
-    renderComponent({ type: 'atk' });
-    expect(screen.getByTestId('atk-badge'));
-  });
-
   it('renders an cio badge', () => {
     renderComponent({ type: 'cio' });
     expect(screen.getByTestId('cio-badge'));

--- a/src/components/Badge/utilities/hasBrandBadge.ts
+++ b/src/components/Badge/utilities/hasBrandBadge.ts
@@ -1,0 +1,6 @@
+type SiteKey = 'atk' | 'cco' | 'cio' | 'kids' | 'play' | 'school' | 'shop'
+const allowedSiteKeys = ['shop', 'school'];
+
+const hasBrandBadge = (siteKey: SiteKey) => allowedSiteKeys.includes(siteKey);
+
+export default hasBrandBadge;

--- a/src/components/Cards/ArticleCard/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard/ArticleCard.tsx
@@ -4,6 +4,7 @@ import { lg, md, untilMd, xxlg } from '../../../styles/breakpoints';
 import { color, font, mixins } from '../../../styles';
 import { cssThemedColor, withThemes, cssThemedTextLinkBold } from '../../../styles/mixins';
 import Badge from '../../Badge';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import cloudinaryInstance, { baseImageConfig } from '../../../lib/cloudinary';
 import Sticker from '../shared/Sticker';
 import { Author, BylineListArticleCard } from '../../BylineList';
@@ -177,7 +178,7 @@ export default function ArticleCard({
 }: ArticleCardProps) {
   const src = cloudinaryInstance.url(cloudinaryId, { ...baseImageConfig, height: 190 });
   const srcLg = cloudinaryInstance.url(cloudinaryId, { ...baseImageConfig, height: 272 });
-
+  const BrandBadge = hasBrandBadge(documentSiteKey);
   return (
     <SplitCard
       linkProps={linkProps}
@@ -189,9 +190,11 @@ export default function ArticleCard({
       )}
       overlay={(
         <>
+          {BrandBadge && (
           <BadgePlacement>
             <Badge type={documentSiteKey} fill={color.transparentBlack} />
           </BadgePlacement>
+          )}
           {!!favoritesObjectId && (
             <FavoritesPlacement>
               <FavoriteRibbonWithBg

--- a/src/components/Cards/FeatureCard/__tests__/FeatureCard.spec.js
+++ b/src/components/Cards/FeatureCard/__tests__/FeatureCard.spec.js
@@ -38,11 +38,6 @@ describe('FeatureCard component should', () => {
     expect(screen.getByText('Tacos Two Ways'));
   });
 
-  it('render a badge', () => {
-    renderComponent();
-    expect(screen.getByTestId('cco-badge'));
-  });
-
   it('render a favorites button', () => {
     renderComponent();
     expect(screen.getByTestId('favorite-button'));

--- a/src/components/Cards/FeatureCard/index.js
+++ b/src/components/Cards/FeatureCard/index.js
@@ -7,6 +7,7 @@ import { cssThemedFontBold } from '../../../styles/mixins';
 import { FeatureCardUserAttributions } from '../shared/UserAttributions';
 import { untilLg } from '../../../styles/breakpoints';
 import Badge from '../../Badge';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import FavoriteRibbonWithBg from '../shared/FavoriteRibbonWithBg';
 import Image from '../shared/Image';
 import PersonHeadShot from '../shared/PersonHeadShot';
@@ -193,6 +194,7 @@ function FeatureCard({
   target,
   title,
 }) {
+  const BrandBadge = hasBrandBadge(siteKey);
   return (
     <StyledFeatureCard
       className={ctaUrl ? 'has-cta feature-card' : 'feature-card'}
@@ -256,7 +258,7 @@ function FeatureCard({
             </div>
           )}
         </div>
-        <StyledBadge className={className} type={siteKey} />
+        {BrandBadge && <StyledBadge className={className} type={siteKey} />}
         {displayFavoritesButton && siteKeyFavorites && objectId ? (
           <StyledFavoriteButtonWithBg
             className={className}

--- a/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
+++ b/src/components/Cards/LeadMarqueeCard/LeadMarqueeCard.tsx
@@ -4,6 +4,7 @@ import breakpoint from 'styled-components-breakpoint';
 import { color, font, fontSize, lineHeight, mixins, spacing, withThemes } from '../../../styles';
 import { md, untilMd } from '../../../styles/breakpoints';
 import Badge from '../../Badge';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import Byline from '../../Byline';
 import FavoriteRibbonWithBg from '../shared/FavoriteRibbonWithBg';
 import Image from '../shared/Image';
@@ -274,72 +275,75 @@ const LeadMarqueeCard = ({
   stickers,
   title,
   onClick = () => {},
-}: LeadMarqueeCardProps) => (
-  <LeadMarqueeCardWrapper>
-    <a
-      href={href}
-      onClick={onClick}
-    >
-      <MarqueeImageWrapper className="lead-marquee-card__image-wrapper">
-        <StyledBadge type={siteKey} />
-        {
-          displayFavoritesRibbon && favoriteObjectId && (
-            <StyledFavoriteButtonWithBg
-              className="lead-marquee-card__favorites-ribbon"
-              siteKey={siteKey}
-              objectId={favoriteObjectId}
-              title={title}
-            />
-          )
-        }
-        <Image
-          className="lead-marquee-card__image"
-          imageUrl={imageUrl}
-          imageAlt={imageAlt}
-        />
-      </MarqueeImageWrapper>
-      <ContentWrapper
-        backgroundColor={backgroundColor}
-        className="lead-marquee-card__content-wrapper"
+}: LeadMarqueeCardProps) => {
+  const BrandBadge = hasBrandBadge(siteKey);
+  return (
+    <LeadMarqueeCardWrapper>
+      <a
+        href={href}
+        onClick={onClick}
       >
-        <div
-          className="lead-marquee-card__content"
-        >
-          { stickers ? (
-            <StickerGroup>
-              {stickers.map(({ text, type }) => (
-                <StyledSticker
-                  key={text}
-                  type={type}
-                  text={text}
-                />
-              ))}
-            </StickerGroup>
-          ) : null }
-          <Title dangerouslySetInnerHTML={{ __html: title }} />
+        <MarqueeImageWrapper className="lead-marquee-card__image-wrapper">
+          {BrandBadge && (<StyledBadge type={siteKey} />)}
           {
-            displayAttributions && (
-              <StyledAttributions
-                commentsCount={commentsCount}
-                numRatings={numRatings}
-                avgRating={avgRating}
+            displayFavoritesRibbon && favoriteObjectId && (
+              <StyledFavoriteButtonWithBg
+                className="lead-marquee-card__favorites-ribbon"
+                siteKey={siteKey}
+                objectId={favoriteObjectId}
+                title={title}
               />
             )
           }
-          <Description dangerouslySetInnerHTML={{ __html: description }} />
-          {authors.length ? (
-            <BylineListLight authors={authors} attribution="" />
-          ) : author ? (
-            <Byline
-              author={`By ${author}`}
-              authorImageCloudinaryId={authorImageCloudinaryId}
-            />
-          ) : null}
+          <Image
+            className="lead-marquee-card__image"
+            imageUrl={imageUrl}
+            imageAlt={imageAlt}
+          />
+        </MarqueeImageWrapper>
+        <ContentWrapper
+          backgroundColor={backgroundColor}
+          className="lead-marquee-card__content-wrapper"
+        >
+          <div
+            className="lead-marquee-card__content"
+          >
+            { stickers ? (
+              <StickerGroup>
+                {stickers.map(({ text, type }) => (
+                  <StyledSticker
+                    key={text}
+                    type={type}
+                    text={text}
+                  />
+                ))}
+              </StickerGroup>
+            ) : null }
+            <Title dangerouslySetInnerHTML={{ __html: title }} />
+            {
+              displayAttributions && (
+                <StyledAttributions
+                  commentsCount={commentsCount}
+                  numRatings={numRatings}
+                  avgRating={avgRating}
+                />
+              )
+            }
+            <Description dangerouslySetInnerHTML={{ __html: description }} />
+            {authors.length ? (
+              <BylineListLight authors={authors} attribution="" />
+            ) : author ? (
+              <Byline
+                author={`By ${author}`}
+                authorImageCloudinaryId={authorImageCloudinaryId}
+              />
+            ) : null}
 
-        </div>
-      </ContentWrapper>
-    </a>
-  </LeadMarqueeCardWrapper>
-);
+          </div>
+        </ContentWrapper>
+      </a>
+    </LeadMarqueeCardWrapper>
+  );
+};
 
 export default LeadMarqueeCard;

--- a/src/components/Cards/LeadMarqueeCard/__tests__/LeadMarqueeCard.spec.js
+++ b/src/components/Cards/LeadMarqueeCard/__tests__/LeadMarqueeCard.spec.js
@@ -27,11 +27,6 @@ describe('LeadMarqueeCard component should', () => {
     )
   );
 
-  it('render a badge', () => {
-    renderComponent();
-    expect(screen.getByTestId('atk-badge'));
-  });
-
   it('render a priority sticker', () => {
     renderComponent();
     expect(screen.getByText('New'));

--- a/src/components/Cards/LoadingRelatedDocumentCard/__tests__/LoadingRelatedDocumentCard.spec.js
+++ b/src/components/Cards/LoadingRelatedDocumentCard/__tests__/LoadingRelatedDocumentCard.spec.js
@@ -23,9 +23,4 @@ describe('LoadingRelatedDocumentCard component should', () => {
     renderComponent();
     expect(screen.getByAltText('loading-related-img'));
   });
-
-  it('render a badge', () => {
-    renderComponent();
-    expect(screen.getByTestId('atk-badge'));
-  });
 });

--- a/src/components/Cards/LoadingRelatedDocumentCard/index.js
+++ b/src/components/Cards/LoadingRelatedDocumentCard/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 import Badge from '../../Badge';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import Image from '../shared/Image';
 import { color, mixins, spacing, withThemes } from '../../../styles';
 import { getImageUrl } from '../../../lib/cloudinary';
@@ -89,34 +90,35 @@ const LoadingRelatedDocumentCard = ({
   hasImage,
   imageAspectRatio,
   siteKey,
-}) => (
-  <LoadingRelatedDocumentCardEl>
-    {hasImage && (
-      <RelatedDocumentImageWrapper>
-        <StyledBadge
-          type={siteKey}
-        />
-        <Image
-          aspectRatio={imageAspectRatio}
-          imageAlt="loading-related-img"
-          imageUrl={getImageUrl(
-            'ATK-S20_20190523_09-46-54_41671_ojahbg',
-            'placeholder',
-            { aspectRatio: imageAspectRatio },
-          )}
-          lazy={false}
-        />
-      </RelatedDocumentImageWrapper>
-    )}
-    <LoadingRelatedDocumentCardContent>
-      <div className="animated-background">
-        <div className="mask-1" />
-        <div className="mask-2" />
-        <div className="mask-3" />
-      </div>
-    </LoadingRelatedDocumentCardContent>
-  </LoadingRelatedDocumentCardEl>
-);
+}) => {
+  const BrandBadge = hasBrandBadge(siteKey);
+  return (
+    <LoadingRelatedDocumentCardEl>
+      {hasImage && (
+        <RelatedDocumentImageWrapper>
+          {BrandBadge && (<StyledBadge type={siteKey} />)}
+          <Image
+            aspectRatio={imageAspectRatio}
+            imageAlt="loading-related-img"
+            imageUrl={getImageUrl(
+              'ATK-S20_20190523_09-46-54_41671_ojahbg',
+              'placeholder',
+              { aspectRatio: imageAspectRatio },
+            )}
+            lazy={false}
+          />
+        </RelatedDocumentImageWrapper>
+      )}
+      <LoadingRelatedDocumentCardContent>
+        <div className="animated-background">
+          <div className="mask-1" />
+          <div className="mask-2" />
+          <div className="mask-3" />
+        </div>
+      </LoadingRelatedDocumentCardContent>
+    </LoadingRelatedDocumentCardEl>
+  );
+};
 
 LoadingRelatedDocumentCard.propTypes = {
   hasImage: PropTypes.bool,

--- a/src/components/Cards/MarqueeCard/__tests__/MarqueeCard.spec.js
+++ b/src/components/Cards/MarqueeCard/__tests__/MarqueeCard.spec.js
@@ -27,11 +27,6 @@ describe('MarqueeCard component should', () => {
     )
   );
 
-  it('render a badge', () => {
-    renderComponent();
-    expect(screen.getByTestId('atk-badge'));
-  });
-
   it('render an editorial sticker', () => {
     renderComponent();
     expect(screen.getByText('Community'));

--- a/src/components/Cards/MarqueeCard/index.js
+++ b/src/components/Cards/MarqueeCard/index.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 import { color, font, fontSize, lineHeight, spacing } from '../../../styles';
 import Badge from '../../Badge';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import Image from '../shared/Image';
 import Sticker from '../shared/Sticker';
 import Byline from '../../Byline';
@@ -108,37 +109,40 @@ const MarqueeCard = ({
   stickers,
   title,
   onClick,
-}) => (
-  <MarqueeCardWrapper>
-    <a
-      href={href}
-      onClick={onClick}
-    >
-      <StyledBadge type={siteKey} />
-      <Image className="article-card__background-image" imageUrl={imageUrl} imageAlt="" />
-      <ContentWrapper>
-        { stickers ? (
-          <StickerGroup>
-            {stickers.map(({ text, type }) => (
-              <StyledSticker
-                key={text}
-                type={type}
-                text={text}
-              />
-            ))}
-          </StickerGroup>
-        ) : null }
-        <Title>{title}</Title>
-        <Description>{description}</Description>
-        <StyledByline
-          author={author}
-          authorImageCloudinaryId={authorImageCloudinaryId}
-          attribution={publishDate}
-        />
-      </ContentWrapper>
-    </a>
-  </MarqueeCardWrapper>
-);
+}) => {
+  const BrandBadge = hasBrandBadge(siteKey);
+  return (
+    <MarqueeCardWrapper>
+      <a
+        href={href}
+        onClick={onClick}
+      >
+        {BrandBadge && (<StyledBadge type={siteKey} />)}
+        <Image className="article-card__background-image" imageUrl={imageUrl} imageAlt="" />
+        <ContentWrapper>
+          { stickers ? (
+            <StickerGroup>
+              {stickers.map(({ text, type }) => (
+                <StyledSticker
+                  key={text}
+                  type={type}
+                  text={text}
+                />
+              ))}
+            </StickerGroup>
+          ) : null }
+          <Title>{title}</Title>
+          <Description>{description}</Description>
+          <StyledByline
+            author={author}
+            authorImageCloudinaryId={authorImageCloudinaryId}
+            attribution={publishDate}
+          />
+        </ContentWrapper>
+      </a>
+    </MarqueeCardWrapper>
+  );
+};
 
 MarqueeCard.propTypes = {
   /** Author Name */

--- a/src/components/Cards/PodcastEpisodeCard/__tests__/PodcastEpisodeCard.spec.js
+++ b/src/components/Cards/PodcastEpisodeCard/__tests__/PodcastEpisodeCard.spec.js
@@ -50,9 +50,4 @@ describe('PodcastEpisodeCard component', () => {
     renderComponent();
     expect(screen.getAllByText('This is the story of one family, struggling to save their bagel cafe in Boston during the COVID-19 pandemic.'));
   });
-
-  it('render an atk badge', () => {
-    renderComponent();
-    expect(screen.getByTestId('atk-badge'));
-  });
 });

--- a/src/components/Cards/PodcastEpisodeCard/index.js
+++ b/src/components/Cards/PodcastEpisodeCard/index.js
@@ -7,6 +7,7 @@ import { color, font, fontSize, spacing, lineHeight, letterSpacing, mixins } fro
 import { VideoPlay } from '../../DesignTokens/Icon';
 
 import Badge from '../../Badge';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import Sticker from '../shared/Sticker';
 import Image from '../shared/Image';
 
@@ -262,7 +263,7 @@ class PodcastEpisodeCard extends Component {
       stickers,
       isPlaying,
     } = this.props;
-
+    const BrandBadge = hasBrandBadge(siteKey);
     return (
       <PodcastEpisodeCardWrapper
         id={id}
@@ -293,9 +294,11 @@ class PodcastEpisodeCard extends Component {
         </div>
         <div>
           <div className="place-hold">
+            {BrandBadge && (
             <StyledBadge
               type={siteKey}
             />
+            )}
             {stickers.map(({ text, type }) => (
               <StyledSticker
                 key={text}

--- a/src/components/Cards/QueueCard/__tests__/QueueCard.spec.js
+++ b/src/components/Cards/QueueCard/__tests__/QueueCard.spec.js
@@ -43,11 +43,6 @@ describe('QueueCard component', () => {
     )
   );
 
-  it('render a badge', () => {
-    renderComponent(inProgressEpisode);
-    expect(screen.getByTestId('atk-badge'));
-  });
-
   it('render an image', () => {
     renderComponent(inProgressEpisode);
     expect(screen.getByAltText('Image alt text'));

--- a/src/components/Cards/QueueCard/index.js
+++ b/src/components/Cards/QueueCard/index.js
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 import { color, fontSize, spacing, lineHeight, font, letterSpacing, withThemes } from '../../../styles';
 import Badge from '../../Badge';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import Image from '../shared/Image';
 import Sticker from '../shared/Sticker';
 import Title from '../shared/Title';
@@ -88,48 +89,53 @@ const QueueCard = ({
   title,
   type,
   videoId,
-}) => (
-  <StyledQueueCard
-    id={videoId}
-    data-testid="queue-card"
-  >
-    <a
-      className="queue-card__anchor"
-      href={href}
-      onClick={onClick}
-      rel={target && target === '_blank' ? 'noopener noreferrer' : null}
-      target={target}
+}) => {
+  const BrandBadge = hasBrandBadge(siteKey);
+  return (
+    <StyledQueueCard
+      id={videoId}
+      data-testid="queue-card"
     >
-      <ImageWrapper>
-        <StyledBadge
-          className={className}
-          type={siteKey}
-        />
-        <Image
-          aria-hidden="true"
-          imageAlt={imageAlt}
-          imageUrl={imageUrl}
-        />
-        { stickers ? (
-          <VideoInfo>
-            {stickers.map(({ text, type }) => (
-              <StyledSticker
-                className={className}
-                key={text}
-                contentType={contentType}
-                type={type}
-                text={text}
-              />
-            ))}
-            <ProgressBar progress={progress} />
-          </VideoInfo>
-        ) : null }
-      </ImageWrapper>
-      <h4>Resume {type} </h4>
-      <StyledTitle className={className} title={title} />
-    </a>
-  </StyledQueueCard>
-);
+      <a
+        className="queue-card__anchor"
+        href={href}
+        onClick={onClick}
+        rel={target && target === '_blank' ? 'noopener noreferrer' : null}
+        target={target}
+      >
+        <ImageWrapper>
+          {BrandBadge && (
+          <StyledBadge
+            className={className}
+            type={siteKey}
+          />
+          )}
+          <Image
+            aria-hidden="true"
+            imageAlt={imageAlt}
+            imageUrl={imageUrl}
+          />
+          { stickers ? (
+            <VideoInfo>
+              {stickers.map(({ text, type }) => (
+                <StyledSticker
+                  className={className}
+                  key={text}
+                  contentType={contentType}
+                  type={type}
+                  text={text}
+                />
+              ))}
+              <ProgressBar progress={progress} />
+            </VideoInfo>
+          ) : null }
+        </ImageWrapper>
+        <h4>Resume {type} </h4>
+        <StyledTitle className={className} title={title} />
+      </a>
+    </StyledQueueCard>
+  );
+};
 
 QueueCard.propTypes = {
   className: PropTypes.string,

--- a/src/components/Cards/RelatedDocumentCard/__tests__/RelatedDocumentCard.spec.js
+++ b/src/components/Cards/RelatedDocumentCard/__tests__/RelatedDocumentCard.spec.js
@@ -36,11 +36,6 @@ describe('RelatedDocumentCard component should', () => {
     expect(screen.getByText('This is the subtitle'));
   });
 
-  it('render a badge', () => {
-    renderComponent();
-    expect(screen.getByTestId('atk-badge'));
-  });
-
   it('render a priority sticker', () => {
     renderComponent();
     expect(screen.getByText('New'));

--- a/src/components/Cards/RelatedDocumentCard/index.js
+++ b/src/components/Cards/RelatedDocumentCard/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 import Badge from '../../Badge';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import Image from '../shared/Image';
 import Sticker from '../shared/Sticker';
 import {
@@ -173,6 +174,7 @@ const RelatedDocumentCard = ({
   target,
   title,
 }) => {
+  const BrandBadge = hasBrandBadge(siteKey);
   let stickerContent = null;
   if (stickers && stickers.length > 0) {
     stickerContent = (
@@ -198,9 +200,11 @@ const RelatedDocumentCard = ({
     >
       {imageUrl && (
         <RelatedDocumentImageWrapper>
+          {BrandBadge && (
           <StyledBadge
             type={siteKey}
           />
+          )}
           <Image
             imageAlt=""
             aspectRatio={imageAspectRatio}

--- a/src/components/Cards/StandardCard/__tests__/StandardCard.spec.js
+++ b/src/components/Cards/StandardCard/__tests__/StandardCard.spec.js
@@ -90,11 +90,6 @@ describe('StandardCard component', () => {
     expect(testInstance.findAllByType(Image).length).toBe(0);
   });
 
-  it('Renders with a correct site badge', () => {
-    const testInstance = componentSetup(baseRecipe);
-    expect(testInstance.findByType(StyledBadge).props.type).toBe(baseRecipe.siteKey);
-  });
-
   it('Renders with a "new" sticker', () => {
     const testInstance = componentSetup(baseRecipe);
     expect(testInstance.findByType(StyledSticker).props.type).toBe('priority');

--- a/src/components/Cards/StandardCard/index.js
+++ b/src/components/Cards/StandardCard/index.js
@@ -6,6 +6,7 @@ import { cards, color, fontSize, spacing, withThemes, mixins } from '../../../st
 import { StandardUserAttributions } from '../shared/UserAttributions/UserAttributions';
 import Attributions from '../shared/Attributions';
 import Badge from '../../Badge';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import CtaLink from '../shared/CtaLink';
 import FavoriteButton from '../shared/FavoriteButton';
 import Image from '../shared/Image';
@@ -204,6 +205,7 @@ function StandardCard({
   quickViewButton,
 }) {
   const ImageItem = Array.isArray(imageUrl) ? ImageCollage : Image;
+  const BrandBadge = hasBrandBadge(siteKey);
   let stickerAria = '';
   if (stickers) {
     stickers.forEach((el) => {
@@ -238,10 +240,12 @@ function StandardCard({
               }
             </a>
           ) : null }
+          {BrandBadge && (
           <StyledBadge
             className={className}
             type={siteKey}
           />
+          )}
           { stickers ? (
             <StickerGroup>
               {stickers.map(({ text, type }) => (

--- a/src/components/Cards/SuggestionCard/__tests__/SuggestionCard.spec.js
+++ b/src/components/Cards/SuggestionCard/__tests__/SuggestionCard.spec.js
@@ -45,11 +45,6 @@ describe('SuggestionCard component', () => {
     expect(screen.getByTestId('suggestion-img-false'));
   });
 
-  it('does renders a badge', () => {
-    renderComponent(baseRecipe);
-    expect(screen.getByTestId('atk-badge'));
-  });
-
   it('does renders a title', () => {
     renderComponent(baseRecipe);
     expect(screen.getByTestId('suggestion-title'));

--- a/src/components/Cards/SuggestionCard/index.js
+++ b/src/components/Cards/SuggestionCard/index.js
@@ -14,6 +14,7 @@ import SuggestionCardSubTitle from './components/SuggestionCardSubTitle';
 import SuggestionCardTitle from './components/SuggestionCardTitle';
 import SuggestionCardWrapper from './components/SuggestionCardWrapper';
 import SuggestionCardStickers from './components/SuggestionCardStickers';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import { Save, Close2 } from '../../DesignTokens/Icon';
 import { color } from '../../../styles';
 
@@ -30,89 +31,94 @@ const SuggestionCard = ({
   comments,
   numRatings,
   resourceType,
-}) => (
-  <SuggestionCardWrapper
-    data-idx={dataIdx}
-  >
-    <SuggestionCardImage
-      data-testid={`suggestion-img-${Boolean(imageUrl)}`}
-      imageUrl={imageUrl}
-      href={href}
-      aria-label={`Go to the ${title} recipe`}
+}) => {
+  const BrandBadge = hasBrandBadge(siteKey);
+  return (
+    <SuggestionCardWrapper
+      data-idx={dataIdx}
     >
-      <SuggestionCardBadge
-        type={siteKey}
-      />
-      <SuggestionCardActions>
-        <div className="button-container">
-          <SuggestionCardAction
-            className="remove-cell primary-hover"
-            data-event-name="RECOMMENDATION_REJECTED"
-            data-document-title={title}
-            data-href={href}
-            data-document-url={href}
-            data-document-type={resourceType}
-            data-object-id={objectId}
-            data-origin-site={siteKey}
-            data-testid="suggestion-action__skip"
-            aria-label={`reject ${title} recipe suggestion`}
+      <SuggestionCardImage
+        data-testid={`suggestion-img-${Boolean(imageUrl)}`}
+        imageUrl={imageUrl}
+        href={href}
+        aria-label={`Go to the ${title} recipe`}
+      >
+        {BrandBadge && (
+        <SuggestionCardBadge
+          type={siteKey}
+        />
+        )}
+        <SuggestionCardActions>
+          <div className="button-container">
+            <SuggestionCardAction
+              className="remove-cell primary-hover"
+              data-event-name="RECOMMENDATION_REJECTED"
+              data-document-title={title}
+              data-href={href}
+              data-document-url={href}
+              data-document-type={resourceType}
+              data-object-id={objectId}
+              data-origin-site={siteKey}
+              data-testid="suggestion-action__skip"
+              aria-label={`reject ${title} recipe suggestion`}
+            >
+              <Close2 />
+            </SuggestionCardAction>
+            <span>Pass</span>
+          </div>
+          <div className="button-container">
+            <SuggestionCardAction
+              className="favorite-action remove-cell primary-hover"
+              data-event-name="RECOMMENDATION_ADDED"
+              data-document-title={title}
+              data-favoritable-id={objectId}
+              data-document-url={href}
+              data-document-type={resourceType}
+              data-object-id={objectId}
+              data-origin-site={siteKey}
+              data-testid="suggestion-action__favorite"
+              aria-label={`save ${title} recipe suggestion`}
+            >
+              <Save className="favorite-ribbon" fill={color.eclipse} />
+            </SuggestionCardAction>
+            <span>Save</span>
+          </div>
+        </SuggestionCardActions>
+      </SuggestionCardImage>
+      <SuggestionCardContent>
+        <SuggestionCardContentInner>
+          {stickers ? (
+            <SuggestionCardStickers
+              stickers={stickers}
+            />
+          ) : null}
+          <SuggestionCardTitle
+            aria-label={`Go to the ${title} recipe`}
+            data-testid="suggestion-title"
+            href={href}
           >
-            <Close2 />
-          </SuggestionCardAction>
-          <span>Pass</span>
-        </div>
-        <div className="button-container">
-          <SuggestionCardAction
-            className="favorite-action remove-cell primary-hover"
-            data-event-name="RECOMMENDATION_ADDED"
-            data-document-title={title}
-            data-favoritable-id={objectId}
-            data-document-url={href}
-            data-document-type={resourceType}
-            data-object-id={objectId}
-            data-origin-site={siteKey}
-            data-testid="suggestion-action__favorite"
-            aria-label={`save ${title} recipe suggestion`}
-          >
-            <Save className="favorite-ribbon" fill={color.eclipse} />
-          </SuggestionCardAction>
-          <span>Save</span>
-        </div>
-      </SuggestionCardActions>
-    </SuggestionCardImage>
-    <SuggestionCardContent>
-      <SuggestionCardContentInner>
-        {stickers ? (
-          <SuggestionCardStickers
-            stickers={stickers}
-          />
-        ) : null}
-        <SuggestionCardTitle
-          aria-label={`Go to the ${title} recipe`}
-          data-testid="suggestion-title"
-          href={href}
-        >
-          {title}
-        </SuggestionCardTitle>
-        {subtitle && (
+            {title}
+          </SuggestionCardTitle>
+          {subtitle && (
           <SuggestionCardSubTitle
             data-testid="suggestion-sub-title"
           >
             {subtitle}
           </SuggestionCardSubTitle>
-        )}
-        <ThemeProvider theme={{ siteKey: 'atk' }}>
-          <UserAttributions
-            avgRating={avgRating}
-            commentsCount={comments}
-            numRatings={numRatings}
-            className="recipe-attributions"
-          />
-        </ThemeProvider>
-      </SuggestionCardContentInner>
-    </SuggestionCardContent>
-  </SuggestionCardWrapper>
-);
+          )}
+          <ThemeProvider theme={{ siteKey: 'atk' }}>
+            <UserAttributions
+              avgRating={avgRating}
+              commentsCount={comments}
+              numRatings={numRatings}
+              className="recipe-attributions"
+            />
+          </ThemeProvider>
+        </SuggestionCardContentInner>
+      </SuggestionCardContent>
+    </SuggestionCardWrapper>
+  );
+};
 
 SuggestionCard.propTypes = {
   avgRating: PropTypes.number,

--- a/src/components/Cards/TallCard/__test__/TallCard.spec.js
+++ b/src/components/Cards/TallCard/__test__/TallCard.spec.js
@@ -33,11 +33,6 @@ describe('TallCard component should', () => {
     expect(screen.getByAltText('Image alt text'));
   });
 
-  it('render a badge', () => {
-    renderComponent();
-    expect(screen.getByTestId('cco-badge'));
-  });
-
   it('render a gradient overlay', () => {
     renderComponent();
     expect(screen.getByTestId('overlay'));

--- a/src/components/Cards/TallCard/index.js
+++ b/src/components/Cards/TallCard/index.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 import { color, font, fontSize, grid, lineHeight, spacing } from '../../../styles';
 import Badge from '../../Badge';
+import hasBrandBadge from '../../Badge/utilities/hasBrandBadge';
 import Image from '../shared/Image';
 import { keyToLogo } from '../../DesignTokens/Logo';
 import Sticker from '../shared/Sticker';
@@ -128,7 +129,7 @@ const TallCard = ({
   target,
 }) => {
   const Logo = keyToLogo(logoKey);
-
+  const BrandBadge = hasBrandBadge(siteKey);
   return (
     <StyledTallCard
       className={imageUrl ? '' : 'no-image'}
@@ -151,10 +152,12 @@ const TallCard = ({
           imageAlt={imageAlt}
           imageUrl={imageUrl}
         />
-        <StyledBadge
-          className={className}
-          type={siteKey}
-        />
+        {BrandBadge && (
+          <StyledBadge
+            className={className}
+            type={siteKey}
+          />
+        )}
         <div className="tall-card__subcomponents-wrapper">
           { stickers && (
             <StickersWrapper>

--- a/src/config/argTypes/index.js
+++ b/src/config/argTypes/index.js
@@ -4,7 +4,7 @@ export const mode = {
 };
 
 export const siteKey = {
-  options: ['atk', 'cco', 'cio', 'play'],
+  options: ['atk', 'cco', 'cio', 'play', 'shop'],
   control: { type: 'inline-radio' },
 };
 


### PR DESCRIPTION
Removing the Brand badge from all cards. Each component that uses the Bade component, is wrapped in a helper function to identify if the badge should be shown. They should be shown ONLY for School and Shop siteKeys. The reason for wrapping the logic in the parent component, is to prevent the rendering of the component unnecessarily. Also to allow for this Badge to be used as intended if not in a card.